### PR TITLE
Feature: dashboard webview shell (#4)

### DIFF
--- a/changelog/2026-03-11-issue-4-dashboard-webview-shell.md
+++ b/changelog/2026-03-11-issue-4-dashboard-webview-shell.md
@@ -1,0 +1,14 @@
+# 2026-03-11 Issue 4 Dashboard Webview Shell
+
+## Summary
+
+- added a packaged Architecture Studio dashboard webview shell with the required top-level sections
+- added a typed webview bridge and a single-panel host controller with reopen-safe lifecycle handling
+- projected shared-contract placeholder and live payloads into dashboard view models
+- added packaged dashboard assets plus user and developer documentation
+
+## Validation
+
+- `npm run verify`
+- `dotnet test core/ArchitectureStudio.sln`
+- `npm run package:extension`

--- a/docs/developer/dashboard-webview.md
+++ b/docs/developer/dashboard-webview.md
@@ -1,0 +1,58 @@
+# Dashboard Webview
+
+## Purpose
+
+The dashboard webview is the first shared UI shell for Architecture Studio. It gives the extension one place to surface:
+
+- architecture state
+- standards composition inputs
+- compliance summaries and findings
+- generated reports and artifacts
+- repository analysis evidence
+
+## Host And Client Boundary
+
+The extension host owns panel lifecycle and data projection:
+
+- `src/dashboard/dashboardController.ts` manages the single active panel, reopen behavior, and typed message routing
+- `src/dashboard/dashboardState.ts` projects shared-contract payloads into a dashboard-oriented DTO
+- `src/dashboard/dashboardHtml.ts` renders the initial HTML shell and references the packaged assets
+
+The webview client owns presentation and interaction:
+
+- `media/dashboard/dashboard.js` receives typed state updates and posts typed command requests back to the host
+- `media/dashboard/dashboard.css` defines the dashboard visual system and responsive layout
+
+## Message Bridge
+
+Host to webview:
+
+- `dashboard.stateChanged`
+
+Webview to host:
+
+- `dashboard.ready`
+- `dashboard.runCommand`
+
+The bridge is intentionally small. The webview consumes DTOs only and does not know about engine internals.
+
+## Lifecycle Rules
+
+- only one dashboard panel is active at a time
+- reopening reveals the existing panel instead of creating duplicates
+- disposing the panel clears the message and dispose subscriptions so handlers do not accumulate
+- the controller can post refreshed state when the panel is revealed again
+
+## Asset Packaging
+
+Dashboard assets live under `media/dashboard/` so they ship directly inside the VSIX and work in local extension debug sessions without a separate frontend bundle pipeline.
+
+## Testing
+
+Issue `#4` adds tests for:
+
+- required dashboard sections
+- shared-contract-backed placeholder and live projection
+- typed message validation
+- panel reuse and dispose/reopen behavior
+- packaged asset and documentation presence

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -18,6 +18,7 @@ Target content:
 Key documents:
 
 - [Command Surface](./command-surface.md)
+- [Dashboard Webview](./dashboard-webview.md)
 - [Release And Publishing](./release-and-publishing.md)
 - [Shared Contracts](./shared-contracts.md)
 

--- a/docs/user/dashboard.md
+++ b/docs/user/dashboard.md
@@ -1,0 +1,37 @@
+# Dashboard
+
+## What It Is
+
+The Architecture Studio dashboard is the main workspace surface for the extension. It brings the most important project views together in one place so you do not have to bounce between separate commands just to understand current status.
+
+The dashboard currently includes:
+
+- Architecture
+- Standards
+- Compliance
+- Reports
+- Repository Analysis
+
+## What You Can Expect
+
+The shell is designed to grow with the rest of the plugin. Early versions may show placeholder data in some sections while the deeper engines are still being implemented, but the layout, command routing, and section model are stable.
+
+Each section is intended to give you:
+
+- a quick summary of current status
+- a focused list of details to review
+- action buttons that route back into the matching extension command
+
+## Why It Matters
+
+This view is the foundation for the product experience and the GitHub Pages story. It gives users a single, visual explanation of what Architecture Studio can do:
+
+- reason about architecture choices
+- compose standards
+- surface compliance risk
+- summarize reports
+- inspect repository analysis evidence
+
+## Current Status
+
+The current dashboard story delivers the shell, message bridge, and packaged assets. Rich screenshots and engine-backed visuals will be added as the downstream stories land.

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -22,3 +22,7 @@ Documentation in this section should:
 - explain value and outcomes clearly
 - include screenshots where they improve clarity
 - use task-focused walkthroughs
+
+Key documents:
+
+- [Dashboard](./dashboard.md)

--- a/media/dashboard/dashboard.css
+++ b/media/dashboard/dashboard.css
@@ -1,0 +1,270 @@
+:root {
+  color-scheme: dark;
+  --bg: #12161f;
+  --bg-accent: #1c2430;
+  --panel: rgba(19, 27, 39, 0.86);
+  --panel-border: rgba(132, 176, 197, 0.22);
+  --text: #f4f1e8;
+  --muted: #aeb7c4;
+  --teal: #74d7c4;
+  --amber: #f3b562;
+  --coral: #f06f5a;
+  --sky: #7da7ff;
+  --shadow: 0 18px 42px rgba(4, 8, 15, 0.28);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Trebuchet MS", "Lucida Sans Unicode", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at top left, rgba(116, 215, 196, 0.12), transparent 32%),
+    radial-gradient(circle at top right, rgba(243, 181, 98, 0.14), transparent 26%),
+    linear-gradient(180deg, #0c1118 0%, #12161f 45%, #151d29 100%);
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+.dashboard-shell {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 28px 24px 40px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(220px, 1fr);
+  gap: 20px;
+  align-items: end;
+  margin-bottom: 26px;
+  padding: 26px;
+  border: 1px solid rgba(116, 215, 196, 0.18);
+  border-radius: 28px;
+  background:
+    linear-gradient(135deg, rgba(24, 34, 47, 0.95), rgba(12, 18, 26, 0.92)),
+    radial-gradient(circle at top left, rgba(125, 167, 255, 0.18), transparent 30%);
+  box-shadow: var(--shadow);
+}
+
+.hero__eyebrow,
+.dashboard-section__eyebrow,
+.hero__meta-label {
+  margin: 0 0 8px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  color: var(--teal);
+}
+
+.hero h1 {
+  margin: 0;
+  font-family: "Palatino Linotype", "Book Antiqua", serif;
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 1;
+}
+
+.hero__subtitle,
+.dashboard-section__description,
+.summary-card__detail,
+.detail-panel li {
+  color: var(--muted);
+}
+
+.hero__subtitle {
+  max-width: 60ch;
+  margin: 14px 0 0;
+  line-height: 1.6;
+}
+
+.hero__meta {
+  justify-self: end;
+  min-width: 0;
+  padding: 16px 18px;
+  border-radius: 20px;
+  background: rgba(8, 12, 19, 0.55);
+  border: 1px solid var(--panel-border);
+}
+
+.hero__meta-value {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+[data-dashboard-root] {
+  display: grid;
+  gap: 20px;
+}
+
+.dashboard-section {
+  padding: 22px;
+  border-radius: 26px;
+  border: 1px solid var(--panel-border);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  animation: fade-up 360ms ease both;
+}
+
+.dashboard-section:nth-child(2) {
+  animation-delay: 40ms;
+}
+
+.dashboard-section:nth-child(3) {
+  animation-delay: 80ms;
+}
+
+.dashboard-section:nth-child(4) {
+  animation-delay: 120ms;
+}
+
+.dashboard-section:nth-child(5) {
+  animation-delay: 160ms;
+}
+
+.dashboard-section__heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  gap: 18px;
+  align-items: end;
+  margin-bottom: 18px;
+}
+
+.dashboard-section__heading h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.dashboard-section__description {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.summary-grid,
+.panel-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.summary-grid {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-bottom: 18px;
+}
+
+.panel-grid {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.summary-card,
+.detail-panel {
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01)),
+    rgba(7, 11, 18, 0.52);
+  padding: 16px 18px;
+}
+
+.summary-card__label,
+.summary-card__value {
+  margin: 0;
+}
+
+.summary-card__label {
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.summary-card__value {
+  margin-top: 10px;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.summary-card__detail {
+  margin-top: 10px;
+  line-height: 1.5;
+}
+
+.summary-card--critical {
+  border-color: rgba(240, 111, 90, 0.32);
+}
+
+.summary-card--warning {
+  border-color: rgba(243, 181, 98, 0.28);
+}
+
+.summary-card--positive {
+  border-color: rgba(116, 215, 196, 0.26);
+}
+
+.detail-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.detail-panel__header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.detail-panel ul {
+  margin: 14px 0 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 8px;
+}
+
+.panel-action {
+  border: 0;
+  border-radius: 999px;
+  padding: 8px 14px;
+  color: #0f1823;
+  background: linear-gradient(135deg, var(--teal), #b6f2d6);
+  cursor: pointer;
+  transition: transform 140ms ease, filter 140ms ease;
+}
+
+.panel-action:hover,
+.panel-action:focus-visible {
+  transform: translateY(-1px);
+  filter: brightness(1.06);
+}
+
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 860px) {
+  .dashboard-shell {
+    padding: 18px 14px 28px;
+  }
+
+  .hero,
+  .dashboard-section__heading {
+    grid-template-columns: 1fr;
+  }
+
+  .hero__meta {
+    justify-self: stretch;
+  }
+}

--- a/media/dashboard/dashboard.js
+++ b/media/dashboard/dashboard.js
@@ -1,0 +1,136 @@
+/* global Element, acquireVsCodeApi, document, window */
+
+(function () {
+  const vscode =
+    typeof acquireVsCodeApi === "function"
+      ? acquireVsCodeApi()
+      : {
+          getState() {
+            return undefined;
+          },
+          postMessage() {},
+          setState() {}
+        };
+
+  function escapeHtml(value) {
+    return String(value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
+  }
+
+  function isStateMessage(message) {
+    return Boolean(
+      message &&
+        typeof message === "object" &&
+        message.type === "dashboard.stateChanged" &&
+        message.state &&
+        Array.isArray(message.state.sections)
+    );
+  }
+
+  function renderSection(section) {
+    const cards = section.cards
+      .map(
+        (card) => `
+          <article class="summary-card summary-card--${escapeHtml(card.tone)}">
+            <p class="summary-card__label">${escapeHtml(card.title)}</p>
+            <p class="summary-card__value">${escapeHtml(card.value)}</p>
+            <p class="summary-card__detail">${escapeHtml(card.detail)}</p>
+          </article>
+        `
+      )
+      .join("");
+
+    const panels = section.panels
+      .map((panel) => {
+        const items = panel.items.map((item) => `<li>${escapeHtml(item)}</li>`).join("");
+        const button = panel.commandId
+          ? `<button class="panel-action" type="button" data-command-id="${escapeHtml(panel.commandId)}">Open</button>`
+          : "";
+
+        return `
+          <article class="detail-panel">
+            <header class="detail-panel__header">
+              <h3>${escapeHtml(panel.title)}</h3>
+              ${button}
+            </header>
+            <ul>${items}</ul>
+          </article>
+        `;
+      })
+      .join("");
+
+    return `
+      <section class="dashboard-section" data-section-id="${escapeHtml(section.id)}">
+        <div class="dashboard-section__heading">
+          <div>
+            <p class="dashboard-section__eyebrow">${escapeHtml(section.title)}</p>
+            <h2>${escapeHtml(section.title)}</h2>
+          </div>
+          <p class="dashboard-section__description">${escapeHtml(section.description)}</p>
+        </div>
+        <div class="summary-grid">${cards}</div>
+        <div class="panel-grid">${panels}</div>
+      </section>
+    `;
+  }
+
+  function render(state) {
+    const root = document.querySelector("[data-dashboard-root]");
+    const generatedAt = document.querySelector("[data-dashboard-generated-at]");
+
+    if (!root) {
+      return;
+    }
+
+    root.innerHTML = state.sections.map(renderSection).join("");
+
+    if (generatedAt) {
+      generatedAt.textContent = state.generatedAt;
+    }
+
+    vscode.setState(state);
+  }
+
+  document.addEventListener("click", (event) => {
+    const target = event.target;
+
+    if (!(target instanceof Element)) {
+      return;
+    }
+
+    const action = target.closest("[data-command-id]");
+
+    if (!action) {
+      return;
+    }
+
+    const commandId = action.getAttribute("data-command-id");
+
+    if (!commandId) {
+      return;
+    }
+
+    vscode.postMessage({
+      type: "dashboard.runCommand",
+      commandId
+    });
+  });
+
+  window.addEventListener("message", (event) => {
+    if (isStateMessage(event.data)) {
+      render(event.data.state);
+    }
+  });
+
+  const cachedState = vscode.getState();
+
+  if (cachedState && Array.isArray(cachedState.sections)) {
+    render(cachedState);
+  }
+
+  vscode.postMessage({ type: "dashboard.ready" });
+})();

--- a/src/commands/commandRuntime.ts
+++ b/src/commands/commandRuntime.ts
@@ -9,11 +9,16 @@ export interface StudioCommandOutput {
   appendLine(line: string): void;
 }
 
+export interface StudioCommandServices {
+  showDashboard?(): Promise<void> | void;
+}
+
 export interface StudioCommandExecutionContext {
   readonly route: StudioCommandRoute;
   readonly host: StudioCommandHost;
   readonly output: StudioCommandOutput;
   readonly arguments: readonly unknown[];
+  readonly services: StudioCommandServices;
 }
 
 export type StudioCommandHandler = (
@@ -55,7 +60,8 @@ function normalizeError(error: unknown): string {
 export function createCommandExecutor(
   route: StudioCommandRoute,
   host: StudioCommandHost,
-  output: StudioCommandOutput
+  output: StudioCommandOutput,
+  services: StudioCommandServices = {}
 ): (...commandArguments: unknown[]) => Promise<void> {
   return async (...commandArguments: unknown[]) => {
     output.appendLine(`[Architecture Studio] Command invoked: ${route.id}`);
@@ -67,7 +73,8 @@ export function createCommandExecutor(
         route,
         host,
         output,
-        arguments: commandArguments
+        arguments: commandArguments,
+        services
       });
     } catch (error) {
       const message = normalizeError(error);

--- a/src/commands/handlers/openDashboardHandler.ts
+++ b/src/commands/handlers/openDashboardHandler.ts
@@ -1,3 +1,11 @@
-import { createPlaceholderCommandHandler } from "./createPlaceholderCommandHandler";
+import type { StudioCommandHandler } from "../commandRuntime";
 
-export default createPlaceholderCommandHandler();
+const openDashboardHandler: StudioCommandHandler = async ({ services }) => {
+  if (!services.showDashboard) {
+    throw new Error("Dashboard services are not configured.");
+  }
+
+  await services.showDashboard();
+};
+
+export default openDashboardHandler;

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -4,6 +4,7 @@ import {
   createCommandExecutor,
   type StudioCommandHost,
   type StudioCommandOutput,
+  type StudioCommandServices,
   studioCommandRoutes
 } from "./commandRuntime";
 
@@ -20,6 +21,7 @@ export interface StudioCommandsApi {
     id: string,
     handler: (...commandArguments: unknown[]) => Promise<void>
   ): DisposableLike;
+  executeCommand?(commandId: string, ...commandArguments: unknown[]): PromiseLike<unknown> | unknown;
 }
 
 export interface StudioVscodeApi {
@@ -29,17 +31,24 @@ export interface StudioVscodeApi {
 
 export const architectureStudioOutputChannelName = "Architecture Studio";
 
+export interface RegisterArchitectureStudioCommandsOptions {
+  readonly services?: StudioCommandServices;
+  readonly createServices?: (outputChannel: StudioOutputChannel) => StudioCommandServices;
+}
+
 export function registerArchitectureStudioCommands(
   context: ExtensionContext,
-  vscodeApi: StudioVscodeApi
+  vscodeApi: StudioVscodeApi,
+  options: RegisterArchitectureStudioCommandsOptions = {}
 ): void {
   const outputChannel = vscodeApi.window.createOutputChannel(architectureStudioOutputChannelName);
+  const services = options.services ?? options.createServices?.(outputChannel) ?? {};
   context.subscriptions.push(outputChannel);
 
   for (const route of studioCommandRoutes) {
     const registration = vscodeApi.commands.registerCommand(
       route.id,
-      createCommandExecutor(route, vscodeApi.window, outputChannel)
+      createCommandExecutor(route, vscodeApi.window, outputChannel, services)
     );
 
     context.subscriptions.push(registration);

--- a/src/dashboard/createStudioCommandServices.ts
+++ b/src/dashboard/createStudioCommandServices.ts
@@ -1,0 +1,36 @@
+import type { StudioCommandOutput, StudioCommandServices } from "../commands/commandRuntime";
+import { ArchitectureStudioDashboardController, type DashboardCommandsApi, type DashboardWindowApi } from "./dashboardController";
+import type { DashboardResourceUri, DashboardUriApi } from "./dashboardHtml";
+
+export type DashboardServiceFactoryContext = {
+  readonly commands: DashboardCommandsApi;
+  readonly extensionUri: DashboardResourceUri;
+  readonly output: StudioCommandOutput;
+  readonly uri: DashboardUriApi;
+  readonly viewColumn: unknown;
+  readonly window: DashboardWindowApi;
+};
+
+export function createStudioCommandServices({
+  commands,
+  extensionUri,
+  output,
+  uri,
+  viewColumn,
+  window
+}: DashboardServiceFactoryContext): StudioCommandServices {
+  const dashboard = new ArchitectureStudioDashboardController({
+    commands,
+    extensionUri,
+    output,
+    uri,
+    viewColumn,
+    window
+  });
+
+  return {
+    async showDashboard() {
+      await dashboard.show();
+    }
+  };
+}

--- a/src/dashboard/dashboardController.ts
+++ b/src/dashboard/dashboardController.ts
@@ -1,0 +1,145 @@
+import type { StudioCommandOutput } from "../commands/commandRuntime";
+import { createDashboardState, createDashboardStateMessage, isDashboardWebviewMessage, type DashboardState } from "./dashboardState";
+import { renderDashboardHtml, type DashboardHtmlWebview, type DashboardResourceUri, type DashboardUriApi } from "./dashboardHtml";
+
+export interface DashboardDisposable {
+  dispose(): void;
+}
+
+export interface DashboardWebview extends DashboardHtmlWebview {
+  html: string;
+  postMessage(message: unknown): PromiseLike<boolean> | boolean;
+  onDidReceiveMessage(listener: (message: unknown) => void): DashboardDisposable;
+}
+
+export interface DashboardPanel {
+  readonly webview: DashboardWebview;
+  reveal(viewColumn?: unknown): void;
+  onDidDispose(listener: () => void): DashboardDisposable;
+}
+
+export interface DashboardWindowApi {
+  createWebviewPanel(
+    viewType: string,
+    title: string,
+    viewColumn: unknown,
+    options: {
+      readonly enableScripts: boolean;
+      readonly localResourceRoots: readonly unknown[];
+      readonly retainContextWhenHidden: boolean;
+    }
+  ): DashboardPanel;
+}
+
+export interface DashboardCommandsApi {
+  executeCommand?(commandId: string): PromiseLike<unknown> | unknown;
+}
+
+type ArchitectureStudioDashboardControllerOptions = {
+  readonly commands: DashboardCommandsApi;
+  readonly extensionUri: DashboardResourceUri;
+  readonly getState?: () => DashboardState;
+  readonly nonceFactory?: () => string;
+  readonly output: StudioCommandOutput;
+  readonly uri: DashboardUriApi;
+  readonly viewColumn: unknown;
+  readonly window: DashboardWindowApi;
+};
+
+export class ArchitectureStudioDashboardController {
+  private activePanel?: DashboardPanel;
+  private activePanelDisposables: DashboardDisposable[] = [];
+
+  public constructor(private readonly options: ArchitectureStudioDashboardControllerOptions) {}
+
+  public async show(): Promise<void> {
+    if (this.activePanel) {
+      this.activePanel.reveal(this.options.viewColumn);
+      await this.postState(this.activePanel);
+      return;
+    }
+
+    const mediaRoot = this.options.uri.joinPath(this.options.extensionUri, "media");
+    const panel = this.options.window.createWebviewPanel(
+      "architectureStudio.dashboard",
+      "Architecture Studio",
+      this.options.viewColumn,
+      {
+        enableScripts: true,
+        localResourceRoots: [this.options.extensionUri, mediaRoot],
+        retainContextWhenHidden: true
+      }
+    );
+    const state = this.getState();
+
+    this.activePanel = panel;
+    panel.webview.html = renderDashboardHtml({
+      extensionUri: this.options.extensionUri,
+      nonce: this.createNonce(),
+      state,
+      uri: this.options.uri,
+      webview: panel.webview
+    });
+
+    const disposeRegistration = panel.onDidDispose(() => {
+      this.options.output.appendLine("[Architecture Studio] Dashboard panel disposed.");
+      this.releasePanel(panel);
+    });
+    const messageRegistration = panel.webview.onDidReceiveMessage((message) => {
+      void this.handleMessage(panel, message);
+    });
+
+    this.activePanelDisposables = [disposeRegistration, messageRegistration];
+  }
+
+  private createNonce(): string {
+    return this.options.nonceFactory?.() ?? Math.random().toString(36).slice(2);
+  }
+
+  private getState(): DashboardState {
+    return this.options.getState?.() ?? createDashboardState();
+  }
+
+  private async handleMessage(panel: DashboardPanel, message: unknown): Promise<void> {
+    if (this.activePanel !== panel) {
+      return;
+    }
+
+    if (!isDashboardWebviewMessage(message)) {
+      this.options.output.appendLine("[Architecture Studio] Dashboard ignored unsupported webview message.");
+      return;
+    }
+
+    switch (message.type) {
+      case "dashboard.ready":
+        this.options.output.appendLine("[Architecture Studio] Dashboard ready message received.");
+        await this.postState(panel);
+        break;
+      case "dashboard.runCommand":
+        this.options.output.appendLine(
+          `[Architecture Studio] Dashboard message received: dashboard.runCommand -> ${message.commandId}`
+        );
+        await this.options.commands.executeCommand?.(message.commandId);
+        break;
+    }
+  }
+
+  private async postState(panel: DashboardPanel): Promise<void> {
+    await panel.webview.postMessage(createDashboardStateMessage(this.getState()));
+  }
+
+  private releasePanel(panel: DashboardPanel): void {
+    if (this.activePanel !== panel) {
+      return;
+    }
+
+    this.activePanel = undefined;
+
+    const disposables = this.activePanelDisposables;
+    this.activePanelDisposables = [];
+
+    for (const disposable of disposables) {
+      disposable.dispose();
+    }
+  }
+}

--- a/src/dashboard/dashboardHtml.ts
+++ b/src/dashboard/dashboardHtml.ts
@@ -1,0 +1,127 @@
+import type { DashboardSection, DashboardState } from "./dashboardState";
+
+export interface DashboardResourceUri {
+  toString(): string;
+}
+
+export interface DashboardUriApi {
+  joinPath(base: DashboardResourceUri, ...paths: string[]): DashboardResourceUri;
+}
+
+export interface DashboardHtmlWebview {
+  readonly cspSource: string;
+  asWebviewUri(resource: DashboardResourceUri): DashboardResourceUri;
+}
+
+type RenderDashboardHtmlOptions = {
+  readonly extensionUri: DashboardResourceUri;
+  readonly nonce: string;
+  readonly state: DashboardState;
+  readonly uri: DashboardUriApi;
+  readonly webview: DashboardHtmlWebview;
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function renderSection(section: DashboardSection): string {
+  const cards = section.cards
+    .map(
+      (card) => `
+        <article class="summary-card summary-card--${card.tone}">
+          <p class="summary-card__label">${escapeHtml(card.title)}</p>
+          <p class="summary-card__value">${escapeHtml(card.value)}</p>
+          <p class="summary-card__detail">${escapeHtml(card.detail)}</p>
+        </article>
+      `
+    )
+    .join("");
+
+  const panels = section.panels
+    .map((panel) => {
+      const items = panel.items.map((item) => `<li>${escapeHtml(item)}</li>`).join("");
+      const action = panel.commandId
+        ? `<button class="panel-action" type="button" data-command-id="${escapeHtml(panel.commandId)}">Open</button>`
+        : "";
+
+      return `
+        <article class="detail-panel">
+          <header class="detail-panel__header">
+            <h3>${escapeHtml(panel.title)}</h3>
+            ${action}
+          </header>
+          <ul>${items}</ul>
+        </article>
+      `;
+    })
+    .join("");
+
+  return `
+    <section class="dashboard-section" data-section-id="${escapeHtml(section.id)}">
+      <div class="dashboard-section__heading">
+        <div>
+          <p class="dashboard-section__eyebrow">${escapeHtml(section.title)}</p>
+          <h2>${escapeHtml(section.title)}</h2>
+        </div>
+        <p class="dashboard-section__description">${escapeHtml(section.description)}</p>
+      </div>
+      <div class="summary-grid">${cards}</div>
+      <div class="panel-grid">${panels}</div>
+    </section>
+  `;
+}
+
+export function renderDashboardHtml({
+  extensionUri,
+  nonce,
+  state,
+  uri,
+  webview
+}: RenderDashboardHtmlOptions): string {
+  const styleUri = webview
+    .asWebviewUri(uri.joinPath(extensionUri, "media", "dashboard", "dashboard.css"))
+    .toString();
+  const scriptUri = webview
+    .asWebviewUri(uri.joinPath(extensionUri, "media", "dashboard", "dashboard.js"))
+    .toString();
+  const sectionsMarkup = state.sections.map((section) => renderSection(section)).join("");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; img-src ${webview.cspSource} data: https:; style-src ${webview.cspSource} 'unsafe-inline'; script-src ${webview.cspSource} 'nonce-${nonce}';"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${escapeHtml(state.title)}</title>
+    <link rel="stylesheet" href="${escapeHtml(styleUri)}" />
+  </head>
+  <body>
+    <div class="dashboard-shell">
+      <header class="hero">
+        <div class="hero__copy">
+          <p class="hero__eyebrow">Architecture Studio Dashboard</p>
+          <h1>${escapeHtml(state.title)}</h1>
+          <p class="hero__subtitle">${escapeHtml(state.subtitle)}</p>
+        </div>
+        <div class="hero__meta">
+          <p class="hero__meta-label">Last generated</p>
+          <p class="hero__meta-value" data-dashboard-generated-at>${escapeHtml(state.generatedAt)}</p>
+        </div>
+      </header>
+      <main data-dashboard-root>
+        ${sectionsMarkup}
+      </main>
+    </div>
+    <script nonce="${escapeHtml(nonce)}" src="${escapeHtml(scriptUri)}"></script>
+  </body>
+</html>`;
+}

--- a/src/dashboard/dashboardState.ts
+++ b/src/dashboard/dashboardState.ts
@@ -1,0 +1,466 @@
+import type {
+  FindingDefinition,
+  GeneratedArtifact,
+  GraphEdgeDefinition,
+  GraphNodeDefinition,
+  ProjectSelectionProfile,
+  ReportArtifact,
+  SharedContractPayload,
+  StandardDefinition
+} from "../contracts/sharedContracts";
+
+export type DashboardSectionId =
+  | "architecture"
+  | "standards"
+  | "compliance"
+  | "reports"
+  | "repository-analysis";
+
+export type DashboardCardTone = "neutral" | "positive" | "warning" | "critical";
+
+export type DashboardSummaryCard = {
+  readonly title: string;
+  readonly value: string;
+  readonly detail: string;
+  readonly tone: DashboardCardTone;
+};
+
+export type DashboardPanel = {
+  readonly title: string;
+  readonly items: readonly string[];
+  readonly commandId?: string;
+};
+
+export type DashboardSection = {
+  readonly id: DashboardSectionId;
+  readonly title: string;
+  readonly description: string;
+  readonly cards: readonly DashboardSummaryCard[];
+  readonly panels: readonly DashboardPanel[];
+};
+
+export type DashboardState = {
+  readonly generatedAt: string;
+  readonly title: string;
+  readonly subtitle: string;
+  readonly sections: readonly DashboardSection[];
+};
+
+export type DashboardHostMessage = {
+  readonly type: "dashboard.stateChanged";
+  readonly state: DashboardState;
+};
+
+export type DashboardWebviewMessage =
+  | {
+      readonly type: "dashboard.ready";
+    }
+  | {
+      readonly type: "dashboard.runCommand";
+      readonly commandId: string;
+    };
+
+const placeholderPayload: SharedContractPayload = {
+  standards: [
+    {
+      id: "std-arch-layering",
+      title: "Service Layering",
+      category: "Architecture",
+      summary: "Keep webview, orchestration, and domain boundaries explicit.",
+      tags: ["modularity", "boundaries", "maintainability"]
+    },
+    {
+      id: "std-testing-tdd",
+      title: "Test Driven Delivery",
+      category: "Testing",
+      summary: "Drive stories through failing tests first and keep regression coverage in place.",
+      tags: ["tdd", "quality", "automation"]
+    }
+  ],
+  regulations: [
+    {
+      id: "reg-soc2-cc7",
+      category: "Security",
+      jurisdiction: "Global",
+      requiredControls: ["ctrl-secrets", "ctrl-audit"],
+      dataTypes: ["SourceCode", "Configuration"]
+    }
+  ],
+  controls: [
+    {
+      id: "ctrl-secrets",
+      title: "Secret Detection",
+      summary: "Detect credentials and rotate compromised values."
+    },
+    {
+      id: "ctrl-audit",
+      title: "Audit Logging",
+      summary: "Capture change history and security-relevant events."
+    }
+  ],
+  graphNodes: [
+    {
+      id: "node-vscode",
+      label: "VS Code Extension Host",
+      category: "Technology"
+    },
+    {
+      id: "node-webview",
+      label: "Dashboard Webview",
+      category: "ArchitecturePattern"
+    },
+    {
+      id: "node-dotnet",
+      label: ".NET Analysis Engine",
+      category: "Framework"
+    }
+  ],
+  graphEdges: [
+    {
+      sourceId: "node-vscode",
+      targetId: "node-webview",
+      relationship: "Requires"
+    },
+    {
+      sourceId: "node-webview",
+      targetId: "node-dotnet",
+      relationship: "PairsWith"
+    }
+  ],
+  findings: [
+    {
+      id: "finding-secret-scan",
+      title: "Secrets scanning placeholder finding",
+      summary: "Repository analysis should validate that committed configuration is scrubbed of credentials.",
+      severity: "High",
+      risk: "Medium",
+      remediation: {
+        title: "Move secrets into secure storage",
+        summary: "Replace inline credentials with a vault-backed configuration source."
+      },
+      evidence: ["src/appsettings.Development.json", "pipelines/build.yml"]
+    },
+    {
+      id: "finding-control-gap",
+      title: "Control mapping placeholder finding",
+      summary: "Compliance summaries should show when required controls are only partially covered.",
+      severity: "Medium",
+      risk: "Medium",
+      remediation: {
+        title: "Complete control mapping",
+        summary: "Link the regulation requirement to enforceable control definitions."
+      },
+      evidence: ["controls/coverage-map.json"]
+    }
+  ],
+  reports: [
+    {
+      id: "report-architecture-overview",
+      title: "Architecture Overview",
+      format: "Markdown",
+      relativePath: "reports/architecture-overview.md"
+    },
+    {
+      id: "report-compliance-summary",
+      title: "Compliance Summary",
+      format: "Markdown",
+      relativePath: "reports/compliance-summary.md"
+    }
+  ],
+  generatedArtifacts: [
+    {
+      id: "artifact-agents",
+      title: "AGENTS.md",
+      kind: "AiInstructions",
+      relativePath: "AGENTS.md"
+    },
+    {
+      id: "artifact-template",
+      title: "Project Scaffold",
+      kind: "ProjectScaffold",
+      relativePath: "templates/projects/README.md"
+    }
+  ],
+  projectSelection: {
+    frontend: "VS Code Webview",
+    backend: ".NET Architecture Engines",
+    architecturePattern: "Modular Extension Shell",
+    ciCd: ["GitHub Actions"],
+    infrastructure: ["GitHub Pages", "Visual Studio Marketplace"],
+    complianceTargets: ["SOC 2", "Security Baseline"]
+  }
+};
+
+function mergeProjectSelection(
+  selection?: Partial<ProjectSelectionProfile>
+): ProjectSelectionProfile {
+  if (!selection) {
+    return placeholderPayload.projectSelection;
+  }
+
+  return {
+    ...placeholderPayload.projectSelection,
+    ...selection,
+    ciCd: selection.ciCd ?? placeholderPayload.projectSelection.ciCd,
+    infrastructure: selection.infrastructure ?? placeholderPayload.projectSelection.infrastructure,
+    complianceTargets: selection.complianceTargets ?? placeholderPayload.projectSelection.complianceTargets
+  };
+}
+
+export function createPlaceholderSharedContractPayload(
+  overrides: Partial<SharedContractPayload> = {}
+): SharedContractPayload {
+  return {
+    ...placeholderPayload,
+    ...overrides,
+    standards: overrides.standards ?? placeholderPayload.standards,
+    regulations: overrides.regulations ?? placeholderPayload.regulations,
+    controls: overrides.controls ?? placeholderPayload.controls,
+    graphNodes: overrides.graphNodes ?? placeholderPayload.graphNodes,
+    graphEdges: overrides.graphEdges ?? placeholderPayload.graphEdges,
+    findings: overrides.findings ?? placeholderPayload.findings,
+    reports: overrides.reports ?? placeholderPayload.reports,
+    generatedArtifacts: overrides.generatedArtifacts ?? placeholderPayload.generatedArtifacts,
+    projectSelection: mergeProjectSelection(overrides.projectSelection)
+  };
+}
+
+function countEvidence(findings: readonly FindingDefinition[]): number {
+  return findings.reduce((total, finding) => total + (finding.evidence?.length ?? 0), 0);
+}
+
+function severityCount(findings: readonly FindingDefinition[], severity: FindingDefinition["severity"]): number {
+  return findings.filter((finding) => finding.severity === severity).length;
+}
+
+function createArchitectureSection(
+  graphNodes: readonly GraphNodeDefinition[],
+  graphEdges: readonly GraphEdgeDefinition[],
+  selection: ProjectSelectionProfile
+): DashboardSection {
+  return {
+    id: "architecture",
+    title: "Architecture",
+    description: "Review the active architecture model, graph relationships, and current build target stack.",
+    cards: [
+      {
+        title: "Graph Nodes",
+        value: String(graphNodes.length),
+        detail: "Technologies, patterns, and controls currently represented.",
+        tone: "neutral"
+      },
+      {
+        title: "Graph Edges",
+        value: String(graphEdges.length),
+        detail: "Known compatibility and dependency relationships.",
+        tone: "positive"
+      },
+      {
+        title: "Target Pattern",
+        value: selection.architecturePattern,
+        detail: `${selection.frontend} with ${selection.backend}.`,
+        tone: "neutral"
+      }
+    ],
+    panels: [
+      {
+        title: "Primary Components",
+        items: graphNodes.map((node) => `${node.label} (${node.category})`),
+        commandId: "architectureStudio.generateArchitecture"
+      },
+      {
+        title: "Delivery Stack",
+        items: [
+          `Frontend: ${selection.frontend}`,
+          `Backend: ${selection.backend}`,
+          `Infrastructure: ${selection.infrastructure.join(", ")}`
+        ],
+        commandId: "architectureStudio.generateProject"
+      }
+    ]
+  };
+}
+
+function createStandardsSection(
+  standards: readonly StandardDefinition[],
+  selection: ProjectSelectionProfile
+): DashboardSection {
+  return {
+    id: "standards",
+    title: "Standards",
+    description: "Track the baseline standards package that should inform architecture and generation decisions.",
+    cards: [
+      {
+        title: "Active Standards",
+        value: String(standards.length),
+        detail: "Curated standards available to compose into solution guidance.",
+        tone: "positive"
+      },
+      {
+        title: "Compliance Targets",
+        value: String(selection.complianceTargets.length),
+        detail: selection.complianceTargets.join(", "),
+        tone: "neutral"
+      }
+    ],
+    panels: [
+      {
+        title: "Current Standard Set",
+        items: standards.map((standard) => `${standard.title}: ${standard.summary}`),
+        commandId: "architectureStudio.composeStandards"
+      }
+    ]
+  };
+}
+
+function createComplianceSection(
+  findings: readonly FindingDefinition[],
+  generatedArtifacts: readonly GeneratedArtifact[]
+): DashboardSection {
+  return {
+    id: "compliance",
+    title: "Compliance",
+    description: "Summarize findings, control coverage, and remediation work from the compliance engine.",
+    cards: [
+      {
+        title: "Critical Findings",
+        value: String(severityCount(findings, "Critical")),
+        detail: "Immediate attention items in the current analysis set.",
+        tone: "critical"
+      },
+      {
+        title: "High Findings",
+        value: String(severityCount(findings, "High")),
+        detail: "Important issues that should be remediated early in delivery.",
+        tone: "warning"
+      },
+      {
+        title: "Generated Guidance",
+        value: String(generatedArtifacts.length),
+        detail: "Artifacts that can support remediation and downstream automation.",
+        tone: "positive"
+      }
+    ],
+    panels: [
+      {
+        title: "Active Findings",
+        items: findings.map((finding) => `${finding.title}: ${finding.summary}`),
+        commandId: "architectureStudio.validateRegulations"
+      },
+      {
+        title: "Remediation Focus",
+        items: findings.map((finding) => `${finding.remediation.title}: ${finding.remediation.summary}`),
+        commandId: "architectureStudio.validateRegulations"
+      }
+    ]
+  };
+}
+
+function createReportsSection(
+  reports: readonly ReportArtifact[],
+  generatedArtifacts: readonly GeneratedArtifact[]
+): DashboardSection {
+  return {
+    id: "reports",
+    title: "Reports",
+    description: "Show the reports and generated outputs that the extension will surface or publish.",
+    cards: [
+      {
+        title: "Reports",
+        value: String(reports.length),
+        detail: "Versioned report artifacts currently mapped in the shared contracts.",
+        tone: "neutral"
+      },
+      {
+        title: "Generated Outputs",
+        value: String(generatedArtifacts.length),
+        detail: "Project, documentation, and AI instruction assets ready for downstream flows.",
+        tone: "positive"
+      }
+    ],
+    panels: [
+      {
+        title: "Available Reports",
+        items: reports.map((report) => `${report.title} (${report.format}) -> ${report.relativePath}`),
+        commandId: "architectureStudio.generateReports"
+      },
+      {
+        title: "Generated Deliverables",
+        items: generatedArtifacts.map((artifact) => `${artifact.title} -> ${artifact.relativePath}`),
+        commandId: "architectureStudio.generateAiInstructions"
+      }
+    ]
+  };
+}
+
+function createRepositoryAnalysisSection(findings: readonly FindingDefinition[]): DashboardSection {
+  return {
+    id: "repository-analysis",
+    title: "Repository Analysis",
+    description: "Inspect repository findings, evidence, and placeholder analysis coverage from one dashboard surface.",
+    cards: [
+      {
+        title: "Findings",
+        value: String(findings.length),
+        detail: "Repository and compliance findings available to inspect.",
+        tone: "neutral"
+      },
+      {
+        title: "Evidence References",
+        value: String(countEvidence(findings)),
+        detail: "Captured files and paths supporting the current findings.",
+        tone: "warning"
+      }
+    ],
+    panels: [
+      {
+        title: "Evidence Trail",
+        items: findings.flatMap((finding) =>
+          (finding.evidence ?? []).map((evidence) => `${finding.title}: ${evidence}`)
+        ),
+        commandId: "architectureStudio.analyzeRepository"
+      },
+      {
+        title: "Review Queue",
+        items: findings.map((finding) => `${finding.severity} - ${finding.title}`),
+        commandId: "architectureStudio.analyzeRepository"
+      }
+    ]
+  };
+}
+
+export function createDashboardState(payload: SharedContractPayload = createPlaceholderSharedContractPayload()): DashboardState {
+  return {
+    generatedAt: new Date().toISOString(),
+    title: "Architecture Studio",
+    subtitle: "Architecture, standards, compliance, reporting, and repository analysis in one command surface.",
+    sections: [
+      createArchitectureSection(payload.graphNodes, payload.graphEdges, payload.projectSelection),
+      createStandardsSection(payload.standards, payload.projectSelection),
+      createComplianceSection(payload.findings, payload.generatedArtifacts),
+      createReportsSection(payload.reports, payload.generatedArtifacts),
+      createRepositoryAnalysisSection(payload.findings)
+    ]
+  };
+}
+
+export function createDashboardStateMessage(state: DashboardState): DashboardHostMessage {
+  return {
+    type: "dashboard.stateChanged",
+    state
+  };
+}
+
+export function isDashboardWebviewMessage(value: unknown): value is DashboardWebviewMessage {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+
+  if (candidate.type === "dashboard.ready") {
+    return true;
+  }
+
+  return candidate.type === "dashboard.runCommand" && typeof candidate.commandId === "string";
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,40 @@
 import * as vscode from "vscode";
 
+import { createStudioCommandServices } from "./dashboard/createStudioCommandServices";
 import { registerArchitectureStudioCommands } from "./commands/registerCommands";
 
 export function activate(context: vscode.ExtensionContext): void {
-  registerArchitectureStudioCommands(context, {
-    commands: vscode.commands,
-    window: vscode.window
-  });
+  registerArchitectureStudioCommands(
+    context,
+    {
+      commands: vscode.commands,
+      window: vscode.window
+    },
+    {
+      createServices: (outputChannel) =>
+        createStudioCommandServices({
+          commands: {
+            executeCommand(commandId) {
+              return vscode.commands.executeCommand(commandId);
+            }
+          },
+          extensionUri: context.extensionUri,
+          output: outputChannel,
+          uri: vscode.Uri,
+          viewColumn: vscode.ViewColumn.One,
+          window: {
+            createWebviewPanel(viewType, title, viewColumn, options) {
+              return vscode.window.createWebviewPanel(
+                viewType,
+                title,
+                viewColumn as vscode.ViewColumn,
+                options as vscode.WebviewPanelOptions & vscode.WebviewOptions
+              );
+            }
+          }
+        })
+    }
+  );
 }
 
 export function deactivate(): void {

--- a/test/commands/registerCommands.test.ts
+++ b/test/commands/registerCommands.test.ts
@@ -14,37 +14,46 @@ function createContext() {
 
 test("registerArchitectureStudioCommands wires the centralized route catalog through a shared output channel", async () => {
   const registered = new Map<string, () => Promise<void>>();
-  const infoMessages: string[] = [];
   const errorMessages: string[] = [];
   const outputLines: string[] = [];
+  let dashboardOpenCount = 0;
   const context = createContext();
 
-  registerArchitectureStudioCommands(context as never, {
-    commands: {
-      registerCommand(id: string, handler: () => Promise<void>): Disposable {
-        registered.set(id, handler);
-        return { dispose() {} };
+  registerArchitectureStudioCommands(
+    context as never,
+    {
+      commands: {
+        registerCommand(id: string, handler: () => Promise<void>): Disposable {
+          registered.set(id, handler);
+          return { dispose() {} };
+        }
+      },
+      window: {
+        createOutputChannel(): { appendLine(line: string): void; dispose(): void } {
+          return {
+            appendLine(line: string) {
+              outputLines.push(line);
+            },
+            dispose() {}
+          };
+        },
+        async showInformationMessage(): Promise<string | undefined> {
+          return undefined;
+        },
+        async showErrorMessage(message: string): Promise<string | undefined> {
+          errorMessages.push(message);
+          return undefined;
+        }
       }
     },
-    window: {
-      createOutputChannel(): { appendLine(line: string): void; dispose(): void } {
-        return {
-          appendLine(line: string) {
-            outputLines.push(line);
-          },
-          dispose() {}
-        };
-      },
-      async showInformationMessage(message: string): Promise<string | undefined> {
-        infoMessages.push(message);
-        return undefined;
-      },
-      async showErrorMessage(message: string): Promise<string | undefined> {
-        errorMessages.push(message);
-        return undefined;
+    {
+      services: {
+        async showDashboard() {
+          dashboardOpenCount += 1;
+        }
       }
     }
-  });
+  );
 
   assert.equal(context.subscriptions.length, studioCommandRoutes.length + 1);
   assert.equal(registered.size, studioCommandRoutes.length);
@@ -54,6 +63,6 @@ test("registerArchitectureStudioCommands wires the centralized route catalog thr
   await registered.get("architectureStudio.openDashboard")?.();
 
   assert.equal(errorMessages.length, 0);
+  assert.equal(dashboardOpenCount, 1);
   assert.ok(outputLines.some((line) => line.includes("architectureStudio.openDashboard")));
-  assert.ok(infoMessages.some((message) => message.includes("Open Dashboard")));
 });

--- a/test/dashboard/dashboardAssets.test.ts
+++ b/test/dashboard/dashboardAssets.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+test("dashboard webview assets and documentation exist in repo paths that package with the extension", () => {
+  const repoRoot = process.cwd();
+  const requiredPaths = [
+    "media/dashboard/dashboard.css",
+    "media/dashboard/dashboard.js",
+    "docs/developer/dashboard-webview.md",
+    "docs/user/dashboard.md"
+  ];
+
+  for (const relativePath of requiredPaths) {
+    assert.ok(fs.existsSync(path.join(repoRoot, relativePath)), `Expected ${relativePath} to exist.`);
+  }
+});

--- a/test/dashboard/dashboardController.test.ts
+++ b/test/dashboard/dashboardController.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ArchitectureStudioDashboardController } from "../../src/dashboard/dashboardController";
+
+type Disposable = { dispose(): void };
+
+class FakeWebview {
+  public html = "";
+  public readonly cspSource = "csp-source";
+  public readonly postedMessages: unknown[] = [];
+  public messageListenerDisposals = 0;
+  private readonly listeners = new Set<(message: unknown) => void>();
+
+  asWebviewUri(resource: { toString(): string }) {
+    return {
+      toString() {
+        return `webview:${resource.toString()}`;
+      }
+    };
+  }
+
+  postMessage(message: unknown) {
+    this.postedMessages.push(message);
+    return true;
+  }
+
+  onDidReceiveMessage(listener: (message: unknown) => void): Disposable {
+    this.listeners.add(listener);
+
+    return {
+      dispose: () => {
+        if (this.listeners.delete(listener)) {
+          this.messageListenerDisposals += 1;
+        }
+      }
+    };
+  }
+
+  emit(message: unknown) {
+    for (const listener of this.listeners) {
+      listener(message);
+    }
+  }
+}
+
+class FakePanel {
+  public readonly webview = new FakeWebview();
+  public revealCount = 0;
+  public disposeListenerDisposals = 0;
+  public disposed = false;
+  private readonly disposeListeners = new Set<() => void>();
+
+  reveal() {
+    this.revealCount += 1;
+  }
+
+  onDidDispose(listener: () => void): Disposable {
+    this.disposeListeners.add(listener);
+
+    return {
+      dispose: () => {
+        if (this.disposeListeners.delete(listener)) {
+          this.disposeListenerDisposals += 1;
+        }
+      }
+    };
+  }
+
+  dispose() {
+    this.disposed = true;
+
+    for (const listener of [...this.disposeListeners]) {
+      listener();
+    }
+  }
+}
+
+function createController() {
+  const createdPanels: FakePanel[] = [];
+  const executedCommands: string[] = [];
+  const outputLines: string[] = [];
+
+  const controller = new ArchitectureStudioDashboardController({
+    extensionUri: {
+      toString() {
+        return "extension:/root";
+      }
+    },
+    output: {
+      appendLine(line: string) {
+        outputLines.push(line);
+      }
+    },
+    commands: {
+      executeCommand(commandId: string) {
+        executedCommands.push(commandId);
+        return undefined;
+      }
+    },
+    uri: {
+      joinPath(base: { toString(): string }, ...paths: string[]) {
+        return {
+          toString() {
+            return [base.toString(), ...paths].join("/");
+          }
+        };
+      }
+    },
+    window: {
+      createWebviewPanel() {
+        const panel = new FakePanel();
+        createdPanels.push(panel);
+        return panel;
+      }
+    },
+    viewColumn: 1,
+    nonceFactory: () => "nonce-test"
+  });
+
+  return { controller, createdPanels, executedCommands, outputLines };
+}
+
+test("dashboard controller renders packaged assets and required sections, and reuses the active panel", async () => {
+  const { controller, createdPanels } = createController();
+
+  await controller.show();
+  await controller.show();
+
+  assert.equal(createdPanels.length, 1);
+  assert.equal(createdPanels[0].revealCount, 1);
+  assert.match(createdPanels[0].webview.html, /Architecture/);
+  assert.match(createdPanels[0].webview.html, /Standards/);
+  assert.match(createdPanels[0].webview.html, /Compliance/);
+  assert.match(createdPanels[0].webview.html, /Reports/);
+  assert.match(createdPanels[0].webview.html, /Repository Analysis/);
+  assert.match(createdPanels[0].webview.html, /dashboard\.css/);
+  assert.match(createdPanels[0].webview.html, /dashboard\.js/);
+});
+
+test("dashboard controller uses the typed message bridge and cleans up listeners across dispose and reopen", async () => {
+  const { controller, createdPanels, executedCommands, outputLines } = createController();
+
+  await controller.show();
+  const firstPanel = createdPanels[0];
+
+  firstPanel.webview.emit({ type: "dashboard.ready" });
+  firstPanel.webview.emit({
+    type: "dashboard.runCommand",
+    commandId: "architectureStudio.composeStandards"
+  });
+
+  assert.equal(firstPanel.webview.postedMessages.length, 1);
+  assert.deepEqual(firstPanel.webview.postedMessages[0], {
+    type: "dashboard.stateChanged",
+    state: firstPanel.webview.postedMessages[0]["state"]
+  });
+  assert.equal(executedCommands[0], "architectureStudio.composeStandards");
+
+  firstPanel.dispose();
+
+  assert.equal(firstPanel.webview.messageListenerDisposals, 1);
+  assert.equal(firstPanel.disposeListenerDisposals, 1);
+
+  await controller.show();
+  assert.equal(createdPanels.length, 2);
+  assert.notEqual(createdPanels[1], firstPanel);
+  assert.ok(outputLines.some((line) => line.includes("dashboard.runCommand")));
+});

--- a/test/dashboard/dashboardState.test.ts
+++ b/test/dashboard/dashboardState.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createDashboardState,
+  createPlaceholderSharedContractPayload,
+  isDashboardWebviewMessage
+} from "../../src/dashboard/dashboardState";
+
+test("dashboard state exposes the required top-level sections with placeholder contract-backed content", () => {
+  const state = createDashboardState();
+
+  assert.deepEqual(
+    state.sections.map((section) => section.title),
+    ["Architecture", "Standards", "Compliance", "Reports", "Repository Analysis"]
+  );
+
+  const compliance = state.sections.find((section) => section.id === "compliance");
+  const repositoryAnalysis = state.sections.find((section) => section.id === "repository-analysis");
+
+  assert.ok(compliance);
+  assert.ok(repositoryAnalysis);
+  assert.ok(compliance.cards.length > 0, "Expected compliance summary cards.");
+  assert.ok(compliance.panels.some((panel) => panel.items.length > 0), "Expected compliance finding panels.");
+  assert.ok(
+    repositoryAnalysis.panels.some((panel) => panel.items.length > 0),
+    "Expected repository analysis placeholder panels."
+  );
+});
+
+test("dashboard state can project live shared-contract payloads into compliance and report sections", () => {
+  const payload = createPlaceholderSharedContractPayload({
+    findings: [
+      {
+        id: "finding-live-1",
+        title: "Secrets committed to source",
+        summary: "A credential was found in a tracked configuration file.",
+        severity: "Critical",
+        risk: "High",
+        remediation: {
+          title: "Rotate and remove secret",
+          summary: "Revoke the current secret, move it into secure storage, and scrub the commit history."
+        },
+        evidence: ["infra/appsettings.json"]
+      }
+    ]
+  });
+  const state = createDashboardState(payload);
+  const compliance = state.sections.find((section) => section.id === "compliance");
+  const reports = state.sections.find((section) => section.id === "reports");
+
+  assert.ok(compliance);
+  assert.ok(reports);
+  assert.ok(compliance.panels.some((panel) => panel.items.some((item) => item.includes("Secrets committed"))));
+  assert.ok(reports.panels.some((panel) => panel.items.some((item) => item.includes(payload.reports[0].title))));
+});
+
+test("dashboard webview message guard accepts only supported typed messages", () => {
+  assert.equal(isDashboardWebviewMessage({ type: "dashboard.ready" }), true);
+  assert.equal(
+    isDashboardWebviewMessage({
+      type: "dashboard.runCommand",
+      commandId: "architectureStudio.composeStandards"
+    }),
+    true
+  );
+  assert.equal(isDashboardWebviewMessage({ type: "dashboard.runCommand" }), false);
+  assert.equal(isDashboardWebviewMessage({ type: "unknown" }), false);
+});


### PR DESCRIPTION
## Summary\n- add a packaged dashboard webview shell with Architecture, Standards, Compliance, Reports, and Repository Analysis sections\n- add a typed host/webview message bridge with a single-panel dashboard controller and reopen-safe lifecycle handling\n- add shared-contract-backed dashboard state projection, packaged media assets, and user/developer docs\n\n## Validation\n- npm run verify\n- dotnet test core/ArchitectureStudio.sln\n- npm run package:extension