### PR TITLE
Wire dashboard to live workspace data

### DIFF
--- a/changelog/2026-03-12-issue-21-live-dashboard.md
+++ b/changelog/2026-03-12-issue-21-live-dashboard.md
@@ -1,0 +1,6 @@
+# Issue 21 Live Dashboard Data
+
+- replaced the shipped sample dashboard default with an explicit live workspace or empty-state model
+- added a dashboard snapshot builder that aggregates repository analysis, standards, architecture, compliance, reports, project generation, and AI-instruction outputs
+- refreshed the dashboard after dashboard-triggered commands and guarded async refreshes from stale overwrites
+- updated user and developer dashboard documentation and added a dashboard screenshot asset under `docs/assets/dashboard/`

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -9,3 +9,7 @@ Guidelines:
 - prefer lossless or high-quality readable images for UI screenshots
 - update screenshots when the UI meaningfully changes
 - link to images with relative paths so the docs remain GitHub Pages friendly
+
+Current feature-area folders:
+
+- `dashboard/`

--- a/docs/assets/dashboard/live-dashboard-fintech.svg
+++ b/docs/assets/dashboard/live-dashboard-fintech.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="960" viewBox="0 0 1440 960" role="img" aria-labelledby="title desc">
+  <title id="title">Architecture Studio live dashboard workspace summary</title>
+  <desc id="desc">Illustrated screenshot of the Architecture Studio dashboard showing a live fintech workspace summary with architecture, standards, compliance, reports, and repository analysis sections.</desc>
+  <rect width="1440" height="960" fill="#f5efe6"/>
+  <rect x="40" y="40" width="1360" height="880" rx="28" fill="#fffaf3" stroke="#d7c4aa" stroke-width="3"/>
+  <rect x="84" y="84" width="1272" height="132" rx="24" fill="#183153"/>
+  <text x="124" y="138" fill="#f6efe2" font-family="'Segoe UI', Arial, sans-serif" font-size="22" font-weight="700">Architecture Studio Dashboard</text>
+  <text x="124" y="178" fill="#ffffff" font-family="'Segoe UI', Arial, sans-serif" font-size="42" font-weight="700">Architecture Studio</text>
+  <text x="124" y="212" fill="#d9e7ff" font-family="'Segoe UI', Arial, sans-serif" font-size="24">Live workspace summary for fintech-platform.</text>
+  <rect x="1098" y="108" width="212" height="84" rx="18" fill="#274a76"/>
+  <text x="1124" y="140" fill="#c8daf7" font-family="'Segoe UI', Arial, sans-serif" font-size="16" font-weight="600">Last generated</text>
+  <text x="1124" y="174" fill="#ffffff" font-family="'Segoe UI', Arial, sans-serif" font-size="22" font-weight="700">2026-03-11T23:55Z</text>
+
+  <g font-family="'Segoe UI', Arial, sans-serif">
+    <rect x="84" y="252" width="612" height="268" rx="22" fill="#fef7ee" stroke="#d8c5ab" stroke-width="2"/>
+    <text x="112" y="294" fill="#946d37" font-size="16" font-weight="700">Architecture</text>
+    <text x="112" y="326" fill="#2a2116" font-size="24" font-weight="700">React + ASP.NET Core</text>
+    <rect x="112" y="352" width="160" height="94" rx="18" fill="#ffffff" stroke="#d8c5ab"/>
+    <text x="130" y="384" fill="#7a6548" font-size="14" font-weight="600">Graph Nodes</text>
+    <text x="130" y="424" fill="#183153" font-size="34" font-weight="700">2</text>
+    <rect x="290" y="352" width="160" height="94" rx="18" fill="#ffffff" stroke="#d8c5ab"/>
+    <text x="308" y="384" fill="#7a6548" font-size="14" font-weight="600">Graph Edges</text>
+    <text x="308" y="424" fill="#183153" font-size="34" font-weight="700">2</text>
+    <rect x="468" y="352" width="196" height="94" rx="18" fill="#ffffff" stroke="#d8c5ab"/>
+    <text x="486" y="384" fill="#7a6548" font-size="14" font-weight="600">Target Pattern</text>
+    <text x="486" y="424" fill="#183153" font-size="24" font-weight="700">clean-architecture</text>
+    <rect x="112" y="462" width="552" height="40" rx="12" fill="#fffdf8" stroke="#d8c5ab"/>
+    <text x="130" y="487" fill="#2a2116" font-size="18">Primary Components: React (Framework), ASP.NET Core (Framework)</text>
+
+    <rect x="744" y="252" width="612" height="268" rx="22" fill="#fef7ee" stroke="#d8c5ab" stroke-width="2"/>
+    <text x="772" y="294" fill="#946d37" font-size="16" font-weight="700">Standards</text>
+    <text x="772" y="326" fill="#2a2116" font-size="24" font-weight="700">Workspace-backed standards selection</text>
+    <rect x="772" y="352" width="170" height="94" rx="18" fill="#ffffff" stroke="#d8c5ab"/>
+    <text x="790" y="384" fill="#7a6548" font-size="14" font-weight="600">Active Standards</text>
+    <text x="790" y="424" fill="#0c7a43" font-size="34" font-weight="700">1</text>
+    <rect x="960" y="352" width="170" height="94" rx="18" fill="#ffffff" stroke="#d8c5ab"/>
+    <text x="978" y="384" fill="#7a6548" font-size="14" font-weight="600">Compliance Targets</text>
+    <text x="978" y="424" fill="#183153" font-size="34" font-weight="700">1</text>
+    <rect x="1148" y="352" width="180" height="94" rx="18" fill="#ffffff" stroke="#d8c5ab"/>
+    <text x="1166" y="384" fill="#7a6548" font-size="14" font-weight="600">External Packs</text>
+    <text x="1166" y="424" fill="#b26a00" font-size="34" font-weight="700">0</text>
+    <rect x="772" y="462" width="556" height="40" rx="12" fill="#fffdf8" stroke="#d8c5ab"/>
+    <text x="790" y="487" fill="#2a2116" font-size="18">Current Standard Set: React Frontend Standard</text>
+
+    <rect x="84" y="548" width="612" height="268" rx="22" fill="#fef7ee" stroke="#d8c5ab" stroke-width="2"/>
+    <text x="112" y="590" fill="#946d37" font-size="16" font-weight="700">Compliance</text>
+    <text x="112" y="622" fill="#2a2116" font-size="24" font-weight="700">PCI DSS findings and remediation</text>
+    <rect x="112" y="648" width="170" height="94" rx="18" fill="#ffffff" stroke="#d8c5ab"/>
+    <text x="130" y="680" fill="#7a6548" font-size="14" font-weight="600">PCI DSS</text>
+    <text x="130" y="720" fill="#a14b2a" font-size="34" font-weight="700">60%</text>
+    <rect x="300" y="648" width="170" height="94" rx="18" fill="#ffffff" stroke="#d8c5ab"/>
+    <text x="318" y="680" fill="#7a6548" font-size="14" font-weight="600">Generated Guidance</text>
+    <text x="318" y="720" fill="#0c7a43" font-size="34" font-weight="700">3</text>
+    <rect x="112" y="758" width="552" height="40" rx="12" fill="#fffdf8" stroke="#d8c5ab"/>
+    <text x="130" y="783" fill="#2a2116" font-size="18">Audit logging gap: Capture payment authorization and admin actions.</text>
+
+    <rect x="744" y="548" width="612" height="268" rx="22" fill="#fef7ee" stroke="#d8c5ab" stroke-width="2"/>
+    <text x="772" y="590" fill="#946d37" font-size="16" font-weight="700">Reports and Repository Analysis</text>
+    <text x="772" y="622" fill="#2a2116" font-size="24" font-weight="700">Generated artifacts and evidence trail</text>
+    <rect x="772" y="648" width="170" height="94" rx="18" fill="#ffffff" stroke="#d8c5ab"/>
+    <text x="790" y="680" fill="#7a6548" font-size="14" font-weight="600">Reports</text>
+    <text x="790" y="720" fill="#183153" font-size="34" font-weight="700">1</text>
+    <rect x="960" y="648" width="170" height="94" rx="18" fill="#ffffff" stroke="#d8c5ab"/>
+    <text x="978" y="680" fill="#7a6548" font-size="14" font-weight="600">Detected Signals</text>
+    <text x="978" y="720" fill="#183153" font-size="34" font-weight="700">2</text>
+    <rect x="1148" y="648" width="180" height="94" rx="18" fill="#ffffff" stroke="#d8c5ab"/>
+    <text x="1166" y="680" fill="#7a6548" font-size="14" font-weight="600">Sensitive Data</text>
+    <text x="1166" y="720" fill="#a14b2a" font-size="34" font-weight="700">1</text>
+    <rect x="772" y="758" width="556" height="40" rx="12" fill="#fffdf8" stroke="#d8c5ab"/>
+    <text x="790" y="783" fill="#2a2116" font-size="18">Deliverables: AGENTS.md, docs/README.md, reports/architecture-report.md</text>
+  </g>
+</svg>

--- a/docs/developer/command-surface.md
+++ b/docs/developer/command-surface.md
@@ -11,7 +11,7 @@ This document defines the stable command entry points exposed by the VS Code ext
 
 | Command ID | Title | Handler Module | Current Behavior |
 | --- | --- | --- | --- |
-| `architectureStudio.openDashboard` | `Architecture Studio: Open Dashboard` | `./handlers/openDashboardHandler` | Routes through the centralized command runtime and shows scaffolded placeholder output |
+| `architectureStudio.openDashboard` | `Architecture Studio: Open Dashboard` | `./handlers/openDashboardHandler` | Routes through the centralized command runtime and opens the live workspace-backed dashboard surface |
 | `architectureStudio.composeStandards` | `Architecture Studio: Compose Standards` | `./handlers/composeStandardsHandler` | Resolves the active workspace, invokes the C# standards-composition path through the core CLI bridge, and reports the composed-standard count |
 | `architectureStudio.analyzeRepository` | `Architecture Studio: Analyze Repository` | `./handlers/analyzeRepositoryHandler` | Resolves the active workspace, invokes the repository-analysis service boundary, and reports structured result counts |
 | `architectureStudio.validateRegulations` | `Architecture Studio: Validate Regulations` | `./handlers/validateRegulationsHandler` | Resolves the active workspace, invokes the compliance service boundary, and reports regulation score summaries plus finding counts |

--- a/docs/developer/dashboard-webview.md
+++ b/docs/developer/dashboard-webview.md
@@ -15,6 +15,7 @@ The dashboard webview is the first shared UI shell for Architecture Studio. It g
 The extension host owns panel lifecycle and data projection:
 
 - `src/dashboard/dashboardController.ts` manages the single active panel, reopen behavior, and typed message routing
+- `src/dashboard/dashboardData.ts` aggregates the live workspace snapshot from the existing command-service engine calls
 - `src/dashboard/dashboardState.ts` projects shared-contract payloads into a dashboard-oriented DTO
 - `src/dashboard/dashboardHtml.ts` renders the initial HTML shell and references the packaged assets
 
@@ -42,17 +43,37 @@ The bridge is intentionally small. The webview consumes DTOs only and does not k
 - reopening reveals the existing panel instead of creating duplicates
 - disposing the panel clears the message and dispose subscriptions so handlers do not accumulate
 - the controller can post refreshed state when the panel is revealed again
+- dashboard-triggered commands refresh the state after execution so the panel does not keep stale data
+- async state refreshes are versioned so older responses do not overwrite newer ones
+
+## Live Snapshot Model
+
+The live dashboard snapshot is assembled in TypeScript as a thin orchestration layer over the C# engines:
+
+- repository analysis drives detected signals and sensitive-data summaries
+- standards composition drives the standards section
+- architecture evaluation drives graph nodes, edges, and architecture findings
+- compliance evaluation drives score cards and remediation findings
+- report generation drives the report artifact list
+- project generation and AI-instruction generation contribute generated deliverables
+
+The default state is now an explicit empty workspace state rather than a shipped sample payload.
 
 ## Asset Packaging
 
 Dashboard assets live under `media/dashboard/` so they ship directly inside the VSIX and work in local extension debug sessions without a separate frontend bundle pipeline.
 
+Illustrated screenshot asset:
+
+- `docs/assets/dashboard/live-dashboard-fintech.svg`
+
 ## Testing
 
-Issue `#4` adds tests for:
+The dashboard test surface now covers:
 
 - required dashboard sections
-- shared-contract-backed placeholder and live projection
+- live workspace snapshot projection
+- explicit no-workspace empty states
 - typed message validation
-- panel reuse and dispose/reopen behavior
+- panel reuse, dispose/reopen behavior, and post-command refresh
 - packaged asset and documentation presence

--- a/docs/user/dashboard.md
+++ b/docs/user/dashboard.md
@@ -12,15 +12,18 @@ The dashboard currently includes:
 - Reports
 - Repository Analysis
 
+![Live dashboard workspace summary](../assets/dashboard/live-dashboard-fintech.svg)
+
 ## What You Can Expect
 
-The shell is designed to grow with the rest of the plugin. Early versions may show placeholder data in some sections while the deeper engines are still being implemented, but the layout, command routing, and section model are stable.
+The dashboard now builds its state from the active workspace instead of sample content. When a folder is open, the cards and detail panels reflect live engine output for architecture, standards, compliance, reports, and repository analysis. When no folder is open, the dashboard stays explicit and tells you to open a workspace instead of silently showing stale or fake values.
 
 Each section is intended to give you:
 
 - a quick summary of current status
 - a focused list of details to review
 - action buttons that route back into the matching extension command
+- deterministic refresh behavior when you reopen the panel or trigger a dashboard action
 
 ## Why It Matters
 
@@ -36,4 +39,11 @@ The compliance section can now render score cards in the same style the product 
 
 ## Current Status
 
-The current dashboard story delivers the shell, message bridge, and packaged assets. Repository analysis is now backed by a real workspace-aware command, while rich screenshots and deeper engine-backed dashboard visuals will continue to land in downstream stories.
+The current dashboard story now delivers:
+
+- the packaged webview shell and typed message bridge
+- live workspace-backed section content
+- explicit no-workspace and no-data empty states
+- refresh after dashboard-triggered commands
+
+Use the sample fintech fixture or your own workspace to see the live cards and evidence panels populate.

--- a/src/commands/commandRuntime.ts
+++ b/src/commands/commandRuntime.ts
@@ -10,6 +10,7 @@ import type {
   AiInstructionGenerationRequest,
   AiInstructionGenerationResult
 } from "../ai/aiInstructionGeneration";
+import type { DashboardState } from "../dashboard/dashboardState";
 
 export interface StudioCommandHost {
   showInformationMessage(message: string): PromiseLike<unknown> | unknown;
@@ -22,6 +23,7 @@ export interface StudioCommandOutput {
 
 export interface StudioCommandServices {
   showDashboard?(): Promise<void> | void;
+  getDashboardState?(): Promise<DashboardState> | DashboardState;
   getWorkspaceFolder?(): Promise<string | undefined> | string | undefined;
   runStandardsComposition?(workspacePath: string): Promise<ComposedStandardsResult> | ComposedStandardsResult;
   runRepositoryAnalysis?(workspacePath: string): Promise<RepositoryAnalysisResult> | RepositoryAnalysisResult;

--- a/src/dashboard/createStudioCommandServices.ts
+++ b/src/dashboard/createStudioCommandServices.ts
@@ -5,6 +5,7 @@ import {
   createArchitectureStudioCoreCli,
   type ArchitectureStudioCoreCli
 } from "../core/architectureStudioCoreCli";
+import { createLiveDashboardState } from "./dashboardData";
 
 export type DashboardServiceFactoryContext = {
   readonly commands: DashboardCommandsApi;
@@ -39,18 +40,25 @@ export function createStudioCommandServices({
           output
         })
       : undefined);
+  let services: StudioCommandServices;
   const dashboard = new ArchitectureStudioDashboardController({
     commands,
     extensionUri,
+    getState() {
+      return createLiveDashboardState(services);
+    },
     output,
     uri,
     viewColumn,
     window
   });
 
-  return {
+  services = {
     async showDashboard() {
       await dashboard.show();
+    },
+    async getDashboardState() {
+      return createLiveDashboardState(services);
     },
     getWorkspaceFolder() {
       return workspace.getFirstWorkspaceFolderPath();
@@ -88,4 +96,6 @@ export function createStudioCommandServices({
         }
       : {})
   };
+
+  return services;
 }

--- a/src/dashboard/dashboardController.ts
+++ b/src/dashboard/dashboardController.ts
@@ -38,7 +38,7 @@ export interface DashboardCommandsApi {
 type ArchitectureStudioDashboardControllerOptions = {
   readonly commands: DashboardCommandsApi;
   readonly extensionUri: DashboardResourceUri;
-  readonly getState?: () => DashboardState;
+  readonly getState?: () => Promise<DashboardState> | DashboardState;
   readonly nonceFactory?: () => string;
   readonly output: StudioCommandOutput;
   readonly uri: DashboardUriApi;
@@ -49,6 +49,7 @@ type ArchitectureStudioDashboardControllerOptions = {
 export class ArchitectureStudioDashboardController {
   private activePanel?: DashboardPanel;
   private activePanelDisposables: DashboardDisposable[] = [];
+  private stateVersion = 0;
 
   public constructor(private readonly options: ArchitectureStudioDashboardControllerOptions) {}
 
@@ -70,9 +71,9 @@ export class ArchitectureStudioDashboardController {
         retainContextWhenHidden: true
       }
     );
-    const state = this.getState();
 
     this.activePanel = panel;
+    const state = await this.getState();
     panel.webview.html = renderDashboardHtml({
       extensionUri: this.options.extensionUri,
       nonce: this.createNonce(),
@@ -96,8 +97,8 @@ export class ArchitectureStudioDashboardController {
     return this.options.nonceFactory?.() ?? Math.random().toString(36).slice(2);
   }
 
-  private getState(): DashboardState {
-    return this.options.getState?.() ?? createDashboardState();
+  private async getState(): Promise<DashboardState> {
+    return (await this.options.getState?.()) ?? createDashboardState();
   }
 
   private async handleMessage(panel: DashboardPanel, message: unknown): Promise<void> {
@@ -120,12 +121,20 @@ export class ArchitectureStudioDashboardController {
           `[Architecture Studio] Dashboard message received: dashboard.runCommand -> ${message.commandId}`
         );
         await this.options.commands.executeCommand?.(message.commandId);
+        await this.postState(panel);
         break;
     }
   }
 
   private async postState(panel: DashboardPanel): Promise<void> {
-    await panel.webview.postMessage(createDashboardStateMessage(this.getState()));
+    const requestedVersion = ++this.stateVersion;
+    const state = await this.getState();
+
+    if (this.activePanel !== panel || requestedVersion !== this.stateVersion) {
+      return;
+    }
+
+    await panel.webview.postMessage(createDashboardStateMessage(state));
   }
 
   private releasePanel(panel: DashboardPanel): void {

--- a/src/dashboard/dashboardData.ts
+++ b/src/dashboard/dashboardData.ts
@@ -1,0 +1,247 @@
+import path from "node:path";
+
+import type { RepositoryAnalysisResult, SensitiveDataClassification } from "../analysis/repositoryAnalysis";
+import type { StudioCommandServices } from "../commands/commandRuntime";
+import type {
+  ComplianceSummary,
+  FindingDefinition,
+  GeneratedArtifact,
+  GraphEdgeDefinition,
+  ProjectSelectionProfile,
+  SharedContractPayload
+} from "../contracts/sharedContracts";
+import type { WorkspaceArchitectureEvaluationResult } from "../graph/technologyGraph";
+import { createDashboardState, createEmptySharedContractPayload, type DashboardState } from "./dashboardState";
+
+type DashboardDataServices = Pick<
+  StudioCommandServices,
+  | "getAiInstructionContext"
+  | "getProjectSelection"
+  | "getWorkspaceFolder"
+  | "runAiInstructionGeneration"
+  | "runArchitectureEvaluation"
+  | "runComplianceEvaluation"
+  | "runProjectGeneration"
+  | "runReportGeneration"
+  | "runRepositoryAnalysis"
+  | "runStandardsComposition"
+>;
+
+const emptyRepositoryAnalysis: RepositoryAnalysisResult = {
+  signals: [],
+  sensitiveData: []
+};
+
+const severityOrder: Record<FindingDefinition["severity"], number> = {
+  Critical: 0,
+  High: 1,
+  Medium: 2,
+  Low: 3
+};
+
+function getWorkspaceLabel(workspacePath: string): string {
+  return path.basename(workspacePath.replace(/\\/g, "/"));
+}
+
+function sortById<T extends { readonly id: string }>(values: readonly T[]): readonly T[] {
+  return [...values].sort((left, right) => left.id.localeCompare(right.id, "en", { sensitivity: "base" }));
+}
+
+function sortGeneratedArtifacts(artifacts: readonly GeneratedArtifact[]): readonly GeneratedArtifact[] {
+  return [...artifacts].sort((left, right) => left.relativePath.localeCompare(right.relativePath, "en", { sensitivity: "base" }));
+}
+
+function sortComplianceSummaries(summaries: readonly ComplianceSummary[]): readonly ComplianceSummary[] {
+  return [...summaries].sort((left, right) =>
+    left.regulationId.localeCompare(right.regulationId, "en", { sensitivity: "base" })
+  );
+}
+
+function sortFindings(findings: readonly FindingDefinition[]): readonly FindingDefinition[] {
+  return [...findings].sort((left, right) => {
+    const severityComparison = severityOrder[left.severity] - severityOrder[right.severity];
+    if (severityComparison !== 0) {
+      return severityComparison;
+    }
+
+    return left.title.localeCompare(right.title, "en", { sensitivity: "base" });
+  });
+}
+
+function combineFindings(...buckets: readonly (readonly FindingDefinition[])[]): readonly FindingDefinition[] {
+  const merged = new Map<string, FindingDefinition>();
+
+  for (const bucket of buckets) {
+    for (const finding of bucket) {
+      merged.set(finding.id, finding);
+    }
+  }
+
+  return sortFindings([...merged.values()]);
+}
+
+function toGeneratedReportArtifacts(reportArtifacts: readonly SharedContractPayload["reports"][number][]): readonly GeneratedArtifact[] {
+  return reportArtifacts.map((artifact) => ({
+    id: artifact.id,
+    title: artifact.title,
+    kind: "Report",
+    relativePath: artifact.relativePath
+  }));
+}
+
+function combineGeneratedArtifacts(...buckets: readonly (readonly GeneratedArtifact[])[]): readonly GeneratedArtifact[] {
+  const merged = new Map<string, GeneratedArtifact>();
+
+  for (const bucket of buckets) {
+    for (const artifact of bucket) {
+      merged.set(artifact.relativePath, artifact);
+    }
+  }
+
+  return sortGeneratedArtifacts([...merged.values()]);
+}
+
+function createSensitiveDataFinding(
+  classification: SensitiveDataClassification,
+  index: number
+): FindingDefinition {
+  const categoryTitle = classification.category.replace("ChildData", "Child Data");
+  const severity =
+    classification.category === "Financial"
+      || classification.category === "Health"
+      || classification.category === "ChildData"
+      ? "High"
+      : "Medium";
+  const evidence = classification.evidence[0] ?? "Sensitive data was detected in the repository.";
+
+  return {
+    id: `sensitive-data-${classification.category.toLowerCase()}-${index}`,
+    title: `${categoryTitle} data detected`,
+    summary: evidence,
+    severity,
+    risk: severity,
+    remediation: {
+      title: `Review ${categoryTitle.toLowerCase()} data handling`,
+      summary: `Confirm storage, access, and retention controls for ${categoryTitle.toLowerCase()} data in the affected files.`
+    },
+    evidence: classification.affectedPaths
+  };
+}
+
+function deriveSensitiveDataFindings(repositoryAnalysis: RepositoryAnalysisResult): readonly FindingDefinition[] {
+  return repositoryAnalysis.sensitiveData.map((classification, index) => createSensitiveDataFinding(classification, index));
+}
+
+function deriveGraphEdges(
+  architectureEvaluation: WorkspaceArchitectureEvaluationResult
+): readonly GraphEdgeDefinition[] {
+  const missingRequirementEdges = architectureEvaluation.technologyEvaluation.missingRequirements.map((requirement) => ({
+    sourceId: requirement.sourceNodeId,
+    targetId: requirement.requiredNodeId,
+    relationship: "Requires" as const
+  }));
+  const conflictEdges = architectureEvaluation.technologyEvaluation.conflicts.map((conflict) => ({
+    sourceId: conflict.leftNodeId,
+    targetId: conflict.rightNodeId,
+    relationship: "Conflicts" as const
+  }));
+  const recommendationEdges = architectureEvaluation.technologyEvaluation.recommendations.map((recommendation) => ({
+    sourceId: recommendation.sourceNodeId,
+    targetId: recommendation.nodeId,
+    relationship: recommendation.relationship
+  }));
+
+  return [...missingRequirementEdges, ...conflictEdges, ...recommendationEdges].sort((left, right) => {
+    const sourceComparison = left.sourceId.localeCompare(right.sourceId, "en", { sensitivity: "base" });
+    if (sourceComparison !== 0) {
+      return sourceComparison;
+    }
+
+    const targetComparison = left.targetId.localeCompare(right.targetId, "en", { sensitivity: "base" });
+    if (targetComparison !== 0) {
+      return targetComparison;
+    }
+
+    return left.relationship.localeCompare(right.relationship, "en", { sensitivity: "base" });
+  });
+}
+
+function getDefaultSelection(): ProjectSelectionProfile {
+  return createEmptySharedContractPayload().projectSelection;
+}
+
+export async function createLiveDashboardState(services: DashboardDataServices): Promise<DashboardState> {
+  const workspacePath = await services.getWorkspaceFolder?.();
+
+  if (!workspacePath) {
+    return createDashboardState(createEmptySharedContractPayload(), {
+      hasWorkspace: false,
+      repositoryAnalysis: emptyRepositoryAnalysis,
+      subtitle: "Open a workspace folder to load live Architecture Studio data."
+    });
+  }
+
+  const [
+    repositoryAnalysis,
+    composedStandards,
+    architectureEvaluation,
+    complianceEvaluation,
+    reportGeneration,
+    projectSelection,
+    aiInstructionContext
+  ] = await Promise.all([
+    services.runRepositoryAnalysis?.(workspacePath) ?? emptyRepositoryAnalysis,
+    services.runStandardsComposition?.(workspacePath) ?? { standards: [], consumerHints: [] },
+    services.runArchitectureEvaluation?.(workspacePath) ?? {
+      technologyEvaluation: {
+        selectedNodes: [],
+        missingRequirements: [],
+        conflicts: [],
+        recommendations: []
+      },
+      findings: []
+    },
+    services.runComplianceEvaluation?.(workspacePath) ?? { summaries: [], findings: [] },
+    services.runReportGeneration?.(workspacePath) ?? { reportArtifacts: [], files: [], pdfFallbackUsed: false },
+    services.getProjectSelection?.() ?? undefined,
+    services.getAiInstructionContext?.(workspacePath) ?? undefined
+  ]);
+
+  const hasProjectSelection = projectSelection !== undefined;
+  const effectiveSelection = projectSelection ?? getDefaultSelection();
+  const [projectGeneration, aiInstructionGeneration] = await Promise.all([
+    hasProjectSelection && services.runProjectGeneration
+      ? services.runProjectGeneration(effectiveSelection)
+      : undefined,
+    aiInstructionContext && services.runAiInstructionGeneration
+      ? services.runAiInstructionGeneration(aiInstructionContext)
+      : undefined
+  ]);
+
+  const reportArtifacts = sortById(reportGeneration.reportArtifacts);
+  const findings = combineFindings(
+    deriveSensitiveDataFindings(repositoryAnalysis),
+    architectureEvaluation.findings,
+    complianceEvaluation.findings
+  );
+  const payload = createEmptySharedContractPayload({
+    standards: composedStandards.standards.map((entry) => entry.definition),
+    graphNodes: sortById(architectureEvaluation.technologyEvaluation.selectedNodes),
+    graphEdges: deriveGraphEdges(architectureEvaluation),
+    complianceSummaries: sortComplianceSummaries(complianceEvaluation.summaries),
+    findings,
+    reports: reportArtifacts,
+    generatedArtifacts: combineGeneratedArtifacts(
+      toGeneratedReportArtifacts(reportArtifacts),
+      projectGeneration?.generatedArtifacts ?? [],
+      aiInstructionGeneration?.generatedArtifacts ?? []
+    ),
+    projectSelection: effectiveSelection
+  });
+
+  return createDashboardState(payload, {
+    hasWorkspace: true,
+    repositoryAnalysis,
+    workspaceLabel: getWorkspaceLabel(workspacePath)
+  });
+}

--- a/src/dashboard/dashboardState.ts
+++ b/src/dashboard/dashboardState.ts
@@ -1,3 +1,4 @@
+import type { RepositoryAnalysisResult } from "../analysis/repositoryAnalysis";
 import type {
   ComplianceSummary,
   FindingDefinition,
@@ -50,6 +51,10 @@ export type DashboardState = {
 
 export type DashboardStateOptions = {
   readonly externalPackageStatuses?: readonly ExternalPackageLoadStatus[];
+  readonly hasWorkspace?: boolean;
+  readonly repositoryAnalysis?: RepositoryAnalysisResult;
+  readonly subtitle?: string;
+  readonly workspaceLabel?: string;
 };
 
 export type DashboardHostMessage = {
@@ -66,7 +71,34 @@ export type DashboardWebviewMessage =
       readonly commandId: string;
     };
 
-const placeholderPayload: SharedContractPayload = {
+const emptyRepositoryAnalysis: RepositoryAnalysisResult = {
+  signals: [],
+  sensitiveData: []
+};
+
+const emptyProjectSelection: ProjectSelectionProfile = {
+  frontend: "Not analyzed",
+  backend: "Not analyzed",
+  architecturePattern: "Not analyzed",
+  ciCd: [],
+  infrastructure: [],
+  complianceTargets: []
+};
+
+const emptyPayload: SharedContractPayload = {
+  standards: [],
+  regulations: [],
+  controls: [],
+  graphNodes: [],
+  graphEdges: [],
+  findings: [],
+  complianceSummaries: [],
+  reports: [],
+  generatedArtifacts: [],
+  projectSelection: emptyProjectSelection
+};
+
+const samplePayload: SharedContractPayload = {
   standards: [
     {
       id: "std-arch-layering",
@@ -136,7 +168,7 @@ const placeholderPayload: SharedContractPayload = {
   findings: [
     {
       id: "finding-secret-scan",
-      title: "Secrets scanning placeholder finding",
+      title: "Secrets scanning sample finding",
       summary: "Repository analysis should validate that committed configuration is scrubbed of credentials.",
       severity: "High",
       risk: "Medium",
@@ -148,7 +180,7 @@ const placeholderPayload: SharedContractPayload = {
     },
     {
       id: "finding-control-gap",
-      title: "Control mapping placeholder finding",
+      title: "Control mapping sample finding",
       summary: "Compliance summaries should show when required controls are only partially covered.",
       severity: "Medium",
       risk: "Medium",
@@ -214,37 +246,39 @@ const placeholderPayload: SharedContractPayload = {
 };
 
 function mergeProjectSelection(
+  base: ProjectSelectionProfile,
   selection?: Partial<ProjectSelectionProfile>
 ): ProjectSelectionProfile {
   if (!selection) {
-    return placeholderPayload.projectSelection;
+    return base;
   }
 
   return {
-    ...placeholderPayload.projectSelection,
+    ...base,
     ...selection,
-    ciCd: selection.ciCd ?? placeholderPayload.projectSelection.ciCd,
-    infrastructure: selection.infrastructure ?? placeholderPayload.projectSelection.infrastructure,
-    complianceTargets: selection.complianceTargets ?? placeholderPayload.projectSelection.complianceTargets
+    ciCd: selection.ciCd ?? base.ciCd,
+    infrastructure: selection.infrastructure ?? base.infrastructure,
+    complianceTargets: selection.complianceTargets ?? base.complianceTargets
   };
 }
 
-export function createPlaceholderSharedContractPayload(
-  overrides: Partial<SharedContractPayload> = {}
+function mergeSharedContractPayload(
+  base: SharedContractPayload,
+  overrides: Partial<SharedContractPayload>
 ): SharedContractPayload {
   return {
-    ...placeholderPayload,
+    ...base,
     ...overrides,
-    standards: overrides.standards ?? placeholderPayload.standards,
-    regulations: overrides.regulations ?? placeholderPayload.regulations,
-    controls: overrides.controls ?? placeholderPayload.controls,
-    graphNodes: overrides.graphNodes ?? placeholderPayload.graphNodes,
-    graphEdges: overrides.graphEdges ?? placeholderPayload.graphEdges,
-    complianceSummaries: overrides.complianceSummaries ?? placeholderPayload.complianceSummaries,
-    findings: overrides.findings ?? placeholderPayload.findings,
-    reports: overrides.reports ?? placeholderPayload.reports,
-    generatedArtifacts: overrides.generatedArtifacts ?? placeholderPayload.generatedArtifacts,
-    projectSelection: mergeProjectSelection(overrides.projectSelection)
+    standards: overrides.standards ?? base.standards,
+    regulations: overrides.regulations ?? base.regulations,
+    controls: overrides.controls ?? base.controls,
+    graphNodes: overrides.graphNodes ?? base.graphNodes,
+    graphEdges: overrides.graphEdges ?? base.graphEdges,
+    complianceSummaries: overrides.complianceSummaries ?? base.complianceSummaries,
+    findings: overrides.findings ?? base.findings,
+    reports: overrides.reports ?? base.reports,
+    generatedArtifacts: overrides.generatedArtifacts ?? base.generatedArtifacts,
+    projectSelection: mergeProjectSelection(base.projectSelection, overrides.projectSelection)
   };
 }
 
@@ -252,15 +286,36 @@ function countEvidence(findings: readonly FindingDefinition[]): number {
   return findings.reduce((total, finding) => total + (finding.evidence?.length ?? 0), 0);
 }
 
-function severityCount(findings: readonly FindingDefinition[], severity: FindingDefinition["severity"]): number {
-  return findings.filter((finding) => finding.severity === severity).length;
+function joinValues(values: readonly string[], fallback: string): string {
+  return values.length > 0 ? values.join(", ") : fallback;
+}
+
+function withFallbackItems(items: readonly string[], fallback: string): readonly string[] {
+  return items.length > 0 ? items : [fallback];
+}
+
+function confidencePercentage(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function createWorkspaceFallbackMessage(hasWorkspace: boolean, emptyWorkspaceMessage: string): string {
+  return hasWorkspace ? emptyWorkspaceMessage : "Open a workspace folder to load live Architecture Studio data.";
 }
 
 function createArchitectureSection(
   graphNodes: readonly GraphNodeDefinition[],
   graphEdges: readonly GraphEdgeDefinition[],
-  selection: ProjectSelectionProfile
+  selection: ProjectSelectionProfile,
+  hasWorkspace: boolean
 ): DashboardSection {
+  const deliveryStackItems = hasWorkspace
+    ? [
+        `Frontend: ${selection.frontend}`,
+        `Backend: ${selection.backend}`,
+        `Infrastructure: ${joinValues(selection.infrastructure, "None detected")}`
+      ]
+    : [createWorkspaceFallbackMessage(false, "No delivery stack data is available for the current workspace.")];
+
   return {
     id: "architecture",
     title: "Architecture",
@@ -269,35 +324,36 @@ function createArchitectureSection(
       {
         title: "Graph Nodes",
         value: String(graphNodes.length),
-        detail: "Technologies, patterns, and controls currently represented.",
-        tone: "neutral"
+        detail: hasWorkspace ? "Technologies and patterns detected for the active workspace." : "Open a workspace to load graph data.",
+        tone: graphNodes.length > 0 ? "positive" : "warning"
       },
       {
         title: "Graph Edges",
         value: String(graphEdges.length),
-        detail: "Known compatibility and dependency relationships.",
-        tone: "positive"
+        detail: hasWorkspace ? "Compatibility, requirement, and recommendation links." : "Workspace-driven graph links appear here.",
+        tone: graphEdges.length > 0 ? "positive" : "warning"
       },
       {
         title: "Target Pattern",
         value: selection.architecturePattern,
-        detail: `${selection.frontend} with ${selection.backend}.`,
-        tone: "neutral"
+        detail: hasWorkspace
+          ? `${selection.frontend} with ${selection.backend}.`
+          : "Open a workspace folder to infer the target architecture pattern.",
+        tone: hasWorkspace ? "neutral" : "warning"
       }
     ],
     panels: [
       {
         title: "Primary Components",
-        items: graphNodes.map((node) => `${node.label} (${node.category})`),
+        items: withFallbackItems(
+          graphNodes.map((node) => `${node.label} (${node.category})`),
+          createWorkspaceFallbackMessage(hasWorkspace, "No architecture components were inferred for the current workspace.")
+        ),
         commandId: "architectureStudio.generateArchitecture"
       },
       {
         title: "Delivery Stack",
-        items: [
-          `Frontend: ${selection.frontend}`,
-          `Backend: ${selection.backend}`,
-          `Infrastructure: ${selection.infrastructure.join(", ")}`
-        ],
+        items: deliveryStackItems,
         commandId: "architectureStudio.generateProject"
       }
     ]
@@ -307,11 +363,12 @@ function createArchitectureSection(
 function createStandardsSection(
   standards: readonly StandardDefinition[],
   selection: ProjectSelectionProfile,
-  externalPackageStatuses: readonly ExternalPackageLoadStatus[]
+  externalPackageStatuses: readonly ExternalPackageLoadStatus[],
+  hasWorkspace: boolean
 ): DashboardSection {
   const externalPackCount = externalPackageStatuses.length;
   const externalPackItems =
-    externalPackageStatuses.length > 0
+    externalPackCount > 0
       ? externalPackageStatuses.map((status) => {
           const contributionKinds =
             status.contributionKinds.length > 0 ? ` [${status.contributionKinds.join(", ")}]` : "";
@@ -322,19 +379,22 @@ function createStandardsSection(
   return {
     id: "standards",
     title: "Standards",
-    description: "Track the baseline standards package that should inform architecture and generation decisions.",
+    description: "Track the standards that inform architecture, delivery, and compliance decisions for the workspace.",
     cards: [
       {
         title: "Active Standards",
         value: String(standards.length),
-        detail: "Curated standards available to compose into solution guidance.",
-        tone: "positive"
+        detail: hasWorkspace ? "Curated standards selected for the current workspace." : "Open a workspace to compose standards.",
+        tone: standards.length > 0 ? "positive" : "warning"
       },
       {
         title: "Compliance Targets",
         value: String(selection.complianceTargets.length),
-        detail: selection.complianceTargets.join(", "),
-        tone: "neutral"
+        detail: joinValues(
+          selection.complianceTargets,
+          hasWorkspace ? "No compliance targets inferred yet." : "Workspace inference will surface compliance targets here."
+        ),
+        tone: selection.complianceTargets.length > 0 ? "neutral" : "warning"
       },
       {
         title: "External Packs",
@@ -349,12 +409,17 @@ function createStandardsSection(
     panels: [
       {
         title: "Current Standard Set",
-        items: standards.map((standard) => `${standard.title}: ${standard.summary}`),
+        items: withFallbackItems(
+          standards.map((standard) => `${standard.title}: ${standard.summary}`),
+          createWorkspaceFallbackMessage(hasWorkspace, "No standards were composed for the current workspace.")
+        ),
         commandId: "architectureStudio.composeStandards"
       },
       {
         title: "External Package Status",
-        items: externalPackItems,
+        items: hasWorkspace
+          ? externalPackItems
+          : [createWorkspaceFallbackMessage(false, "No external packages discovered yet.")],
         commandId: "architectureStudio.composeStandards"
       }
     ]
@@ -364,7 +429,8 @@ function createStandardsSection(
 function createComplianceSection(
   complianceSummaries: readonly ComplianceSummary[],
   findings: readonly FindingDefinition[],
-  generatedArtifacts: readonly GeneratedArtifact[]
+  generatedArtifacts: readonly GeneratedArtifact[],
+  hasWorkspace: boolean
 ): DashboardSection {
   const summaryCards =
     complianceSummaries.length > 0
@@ -381,16 +447,16 @@ function createComplianceSection(
         }))
       : [
           {
-            title: "Critical Findings",
-            value: String(severityCount(findings, "Critical")),
-            detail: "Immediate attention items in the current analysis set.",
-            tone: "critical" as const
+            title: "Applicable Regulations",
+            value: "0",
+            detail: hasWorkspace ? "No regulations were inferred for the current workspace." : "Open a workspace to evaluate regulations.",
+            tone: "warning" as const
           },
           {
-            title: "High Findings",
-            value: String(severityCount(findings, "High")),
-            detail: "Important issues that should be remediated early in delivery.",
-            tone: "warning" as const
+            title: "Findings",
+            value: String(findings.length),
+            detail: hasWorkspace ? "Compliance and architecture findings currently in scope." : "Workspace findings will appear here.",
+            tone: findings.length > 0 ? ("warning" as const) : ("neutral" as const)
           }
         ];
 
@@ -403,19 +469,25 @@ function createComplianceSection(
       {
         title: "Generated Guidance",
         value: String(generatedArtifacts.length),
-        detail: "Artifacts that can support remediation and downstream automation.",
-        tone: "positive"
+        detail: hasWorkspace ? "Artifacts available for remediation and downstream automation." : "Generated guidance appears after workspace analysis.",
+        tone: generatedArtifacts.length > 0 ? "positive" : "warning"
       }
     ],
     panels: [
       {
         title: "Active Findings",
-        items: findings.map((finding) => `${finding.title}: ${finding.summary}`),
+        items: withFallbackItems(
+          findings.map((finding) => `${finding.title}: ${finding.summary}`),
+          createWorkspaceFallbackMessage(hasWorkspace, "No compliance findings were generated for the current workspace.")
+        ),
         commandId: "architectureStudio.validateRegulations"
       },
       {
         title: "Remediation Focus",
-        items: findings.map((finding) => `${finding.remediation.title}: ${finding.remediation.summary}`),
+        items: withFallbackItems(
+          findings.map((finding) => `${finding.remediation.title}: ${finding.remediation.summary}`),
+          createWorkspaceFallbackMessage(hasWorkspace, "No remediation actions are currently required for the workspace snapshot.")
+        ),
         commandId: "architectureStudio.validateRegulations"
       }
     ]
@@ -424,93 +496,148 @@ function createComplianceSection(
 
 function createReportsSection(
   reports: readonly ReportArtifact[],
-  generatedArtifacts: readonly GeneratedArtifact[]
+  generatedArtifacts: readonly GeneratedArtifact[],
+  hasWorkspace: boolean
 ): DashboardSection {
   return {
     id: "reports",
     title: "Reports",
-    description: "Show the reports and generated outputs that the extension will surface or publish.",
+    description: "Show the reports and generated outputs that the extension can surface or publish for the workspace.",
     cards: [
       {
         title: "Reports",
         value: String(reports.length),
-        detail: "Versioned report artifacts currently mapped in the shared contracts.",
-        tone: "neutral"
+        detail: hasWorkspace ? "Report artifacts available from the current workspace snapshot." : "Open a workspace to generate live report artifacts.",
+        tone: reports.length > 0 ? "positive" : "warning"
       },
       {
         title: "Generated Outputs",
         value: String(generatedArtifacts.length),
-        detail: "Project, documentation, and AI instruction assets ready for downstream flows.",
-        tone: "positive"
+        detail: hasWorkspace ? "Project, documentation, AI, and report deliverables in scope." : "Workspace-driven deliverables appear here after analysis.",
+        tone: generatedArtifacts.length > 0 ? "positive" : "warning"
       }
     ],
     panels: [
       {
         title: "Available Reports",
-        items: reports.map((report) => `${report.title} (${report.format}) -> ${report.relativePath}`),
+        items: withFallbackItems(
+          reports.map((report) => `${report.title} (${report.format}) -> ${report.relativePath}`),
+          createWorkspaceFallbackMessage(hasWorkspace, "No report artifacts were generated for the current workspace.")
+        ),
         commandId: "architectureStudio.generateReports"
       },
       {
         title: "Generated Deliverables",
-        items: generatedArtifacts.map((artifact) => `${artifact.title} -> ${artifact.relativePath}`),
+        items: withFallbackItems(
+          generatedArtifacts.map((artifact) => `${artifact.title} -> ${artifact.relativePath}`),
+          createWorkspaceFallbackMessage(hasWorkspace, "No generated deliverables are available for the current workspace snapshot.")
+        ),
         commandId: "architectureStudio.generateAiInstructions"
       }
     ]
   };
 }
 
-function createRepositoryAnalysisSection(findings: readonly FindingDefinition[]): DashboardSection {
+function createRepositoryAnalysisSection(
+  repositoryAnalysis: RepositoryAnalysisResult,
+  findings: readonly FindingDefinition[],
+  hasWorkspace: boolean
+): DashboardSection {
   return {
     id: "repository-analysis",
     title: "Repository Analysis",
-    description: "Inspect repository findings, evidence, and placeholder analysis coverage from one dashboard surface.",
+    description: "Inspect detected technologies, sensitive-data signals, evidence, and review work from one dashboard surface.",
     cards: [
       {
-        title: "Findings",
-        value: String(findings.length),
-        detail: "Repository and compliance findings available to inspect.",
-        tone: "neutral"
+        title: "Detected Signals",
+        value: String(repositoryAnalysis.signals.length),
+        detail: hasWorkspace ? "Languages, frameworks, patterns, and delivery signals inferred from the workspace." : "Open a workspace to run repository analysis.",
+        tone: repositoryAnalysis.signals.length > 0 ? "positive" : "warning"
+      },
+      {
+        title: "Sensitive Data",
+        value: String(repositoryAnalysis.sensitiveData.length),
+        detail: hasWorkspace ? "Sensitive-data classifications inferred from repository evidence." : "Sensitive-data classifications appear after analysis.",
+        tone: repositoryAnalysis.sensitiveData.length > 0 ? "warning" : "neutral"
       },
       {
         title: "Evidence References",
         value: String(countEvidence(findings)),
-        detail: "Captured files and paths supporting the current findings.",
-        tone: "warning"
+        detail: hasWorkspace ? "Captured files and paths supporting the current findings." : "Finding evidence is populated after analysis.",
+        tone: countEvidence(findings) > 0 ? "warning" : "neutral"
       }
     ],
     panels: [
       {
-        title: "Evidence Trail",
-        items: findings.flatMap((finding) =>
-          (finding.evidence ?? []).map((evidence) => `${finding.title}: ${evidence}`)
+        title: "Detected Stack",
+        items: withFallbackItems(
+          repositoryAnalysis.signals.map(
+            (signal) => `${signal.label} (${signal.category}) - ${confidencePercentage(signal.confidence)} confidence`
+          ),
+          createWorkspaceFallbackMessage(hasWorkspace, "No repository technology signals were inferred for the current workspace.")
+        ),
+        commandId: "architectureStudio.analyzeRepository"
+      },
+      {
+        title: "Sensitive Data",
+        items: withFallbackItems(
+          repositoryAnalysis.sensitiveData.map((classification) => {
+            const evidence = classification.evidence[0] ?? "Repository evidence detected.";
+            return `${classification.category} data - ${evidence}`;
+          }),
+          createWorkspaceFallbackMessage(hasWorkspace, "No sensitive-data classifications were detected for the current workspace.")
         ),
         commandId: "architectureStudio.analyzeRepository"
       },
       {
         title: "Review Queue",
-        items: findings.map((finding) => `${finding.severity} - ${finding.title}`),
+        items: withFallbackItems(
+          findings.map((finding) => `${finding.severity} - ${finding.title}`),
+          createWorkspaceFallbackMessage(hasWorkspace, "No repository or compliance findings are waiting for review.")
+        ),
         commandId: "architectureStudio.analyzeRepository"
       }
     ]
   };
 }
 
+export function createEmptySharedContractPayload(
+  overrides: Partial<SharedContractPayload> = {}
+): SharedContractPayload {
+  return mergeSharedContractPayload(emptyPayload, overrides);
+}
+
+export function createSampleSharedContractPayload(
+  overrides: Partial<SharedContractPayload> = {}
+): SharedContractPayload {
+  return mergeSharedContractPayload(samplePayload, overrides);
+}
+
 export function createDashboardState(
-  payload: SharedContractPayload = createPlaceholderSharedContractPayload(),
+  payload: SharedContractPayload = createEmptySharedContractPayload(),
   options: DashboardStateOptions = {}
 ): DashboardState {
   const externalPackageStatuses = options.externalPackageStatuses ?? [];
+  const hasWorkspace = options.hasWorkspace ?? Boolean(options.workspaceLabel);
+  const repositoryAnalysis = options.repositoryAnalysis ?? emptyRepositoryAnalysis;
+  const subtitle =
+    options.subtitle
+    ?? (options.workspaceLabel
+      ? `Live workspace summary for ${options.workspaceLabel}.`
+      : hasWorkspace
+        ? "Live workspace summary for the active workspace."
+        : "Open a workspace folder to load live Architecture Studio data.");
 
   return {
     generatedAt: new Date().toISOString(),
     title: "Architecture Studio",
-    subtitle: "Architecture, standards, compliance, reporting, and repository analysis in one command surface.",
+    subtitle,
     sections: [
-      createArchitectureSection(payload.graphNodes, payload.graphEdges, payload.projectSelection),
-      createStandardsSection(payload.standards, payload.projectSelection, externalPackageStatuses),
-      createComplianceSection(payload.complianceSummaries, payload.findings, payload.generatedArtifacts),
-      createReportsSection(payload.reports, payload.generatedArtifacts),
-      createRepositoryAnalysisSection(payload.findings)
+      createArchitectureSection(payload.graphNodes, payload.graphEdges, payload.projectSelection, hasWorkspace),
+      createStandardsSection(payload.standards, payload.projectSelection, externalPackageStatuses, hasWorkspace),
+      createComplianceSection(payload.complianceSummaries, payload.findings, payload.generatedArtifacts, hasWorkspace),
+      createReportsSection(payload.reports, payload.generatedArtifacts, hasWorkspace),
+      createRepositoryAnalysisSection(repositoryAnalysis, payload.findings, hasWorkspace)
     ]
   };
 }

--- a/test/dashboard/createStudioCommandServices.test.ts
+++ b/test/dashboard/createStudioCommandServices.test.ts
@@ -114,6 +114,7 @@ test("createStudioCommandServices delegates workspace-aware operations to the co
   await services.runReportGeneration?.("C:/workspace/sample");
   const aiContext = await services.getAiInstructionContext?.("C:/workspace/sample");
   await services.runAiInstructionGeneration?.(aiContext!);
+  const dashboardState = await services.getDashboardState?.();
 
   assert.deepEqual(invokedCommands, [
     "analyze:C:/workspace/sample",
@@ -124,6 +125,17 @@ test("createStudioCommandServices delegates workspace-aware operations to the co
     "project:react",
     "reports:C:/workspace/sample",
     "ai-context:C:/workspace/sample",
+    "ai:Architecture Studio",
+    "analyze:C:/workspace/sample",
+    "standards:C:/workspace/sample",
+    "architecture:C:/workspace/sample",
+    "compliance:C:/workspace/sample",
+    "reports:C:/workspace/sample",
+    "selection:C:/workspace/sample",
+    "ai-context:C:/workspace/sample",
+    "project:react",
     "ai:Architecture Studio"
   ]);
+  assert.ok(dashboardState);
+  assert.equal(dashboardState.subtitle, "Live workspace summary for sample.");
 });

--- a/test/dashboard/dashboardController.test.ts
+++ b/test/dashboard/dashboardController.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { ArchitectureStudioDashboardController } from "../../src/dashboard/dashboardController";
+import { createEmptySharedContractPayload, createSampleSharedContractPayload, createDashboardState } from "../../src/dashboard/dashboardState";
 
 type Disposable = { dispose(): void };
 
@@ -149,6 +150,7 @@ test("dashboard controller uses the typed message bridge and cleans up listeners
     type: "dashboard.runCommand",
     commandId: "architectureStudio.composeStandards"
   });
+  await new Promise((resolve) => setImmediate(resolve));
 
   assert.equal(firstPanel.webview.postedMessages.length, 1);
   assert.deepEqual(firstPanel.webview.postedMessages[0], {
@@ -166,4 +168,77 @@ test("dashboard controller uses the typed message bridge and cleans up listeners
   assert.equal(createdPanels.length, 2);
   assert.notEqual(createdPanels[1], firstPanel);
   assert.ok(outputLines.some((line) => line.includes("dashboard.runCommand")));
+});
+
+test("dashboard controller refreshes live state after a dashboard-triggered command", async () => {
+  let currentState = createDashboardState(
+    createSampleSharedContractPayload({
+      complianceSummaries: [
+        {
+          regulationId: "pci-dss",
+          regulationTitle: "PCI DSS",
+          scorePercentage: 60,
+          coveredControls: 3,
+          totalControls: 5
+        }
+      ]
+    }),
+    {
+      workspaceLabel: "fintech-platform"
+    }
+  );
+  const createdPanels: FakePanel[] = [];
+
+  const controller = new ArchitectureStudioDashboardController({
+    extensionUri: {
+      toString() {
+        return "extension:/root";
+      }
+    },
+    getState: async () => currentState,
+    output: {
+      appendLine() {}
+    },
+    commands: {
+      async executeCommand() {
+        currentState = createDashboardState(createEmptySharedContractPayload(), {
+          workspaceLabel: "fintech-platform",
+          subtitle: "Live workspace summary for fintech-platform."
+        });
+      }
+    },
+    uri: {
+      joinPath(base: { toString(): string }, ...paths: string[]) {
+        return {
+          toString() {
+            return [base.toString(), ...paths].join("/");
+          }
+        };
+      }
+    },
+    window: {
+      createWebviewPanel() {
+        const panel = new FakePanel();
+        createdPanels.push(panel);
+        return panel;
+      }
+    },
+    viewColumn: 1,
+    nonceFactory: () => "nonce-test"
+  });
+
+  await controller.show();
+  const panel = createdPanels[0];
+
+  panel.webview.emit({
+    type: "dashboard.runCommand",
+    commandId: "architectureStudio.generateReports"
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(panel.webview.postedMessages.length, 1);
+  assert.equal(
+    (panel.webview.postedMessages[0] as { state: { subtitle: string } }).state.subtitle,
+    "Live workspace summary for fintech-platform."
+  );
 });

--- a/test/dashboard/dashboardData.test.ts
+++ b/test/dashboard/dashboardData.test.ts
@@ -1,0 +1,262 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { StudioCommandServices } from "../../src/commands/commandRuntime";
+import { createLiveDashboardState } from "../../src/dashboard/dashboardData";
+
+test("live dashboard state aggregates workspace-backed engine output", async () => {
+  const services: StudioCommandServices = {
+    getWorkspaceFolder() {
+      return "C:/workspace/fintech-platform";
+    },
+    async runRepositoryAnalysis() {
+      return {
+        signals: [
+          {
+            id: "react",
+            label: "React",
+            category: "Framework",
+            confidence: 0.95,
+            evidence: ["Detected React dependency."],
+            affectedPaths: ["clients/portal/package.json"]
+          },
+          {
+            id: "github-actions",
+            label: "GitHub Actions",
+            category: "CiCd",
+            confidence: 0.99,
+            evidence: ["Detected GitHub Actions workflow file."],
+            affectedPaths: [".github/workflows/ci.yml"]
+          }
+        ],
+        sensitiveData: [
+          {
+            category: "Financial",
+            confidence: 0.92,
+            evidence: ["Financial data indicator matched 'creditCard' in src/Web/appsettings.json."],
+            affectedPaths: ["src/Web/appsettings.json"]
+          }
+        ]
+      };
+    },
+    async runStandardsComposition() {
+      return {
+        standards: [
+          {
+            definition: {
+              id: "react",
+              title: "React Frontend Standard",
+              category: "Frontend",
+              summary: "Use React for the customer portal.",
+              tags: ["react", "frontend"]
+            },
+            source: {
+              packageId: "core",
+              packageVersion: "1.0.0",
+              sourcePath: "standards/frontend/react.json",
+              sourceTitle: "React"
+            },
+            selectionReasons: ["Detected workspace frontend."]
+          }
+        ],
+        consumerHints: []
+      };
+    },
+    async runArchitectureEvaluation() {
+      return {
+        technologyEvaluation: {
+          selectedNodes: [
+            {
+              id: "react",
+              label: "React",
+              category: "Framework"
+            },
+            {
+              id: "aspnet-core",
+              label: "ASP.NET Core",
+              category: "Framework"
+            }
+          ],
+          missingRequirements: [
+            {
+              sourceNodeId: "react",
+              requiredNodeId: "typescript"
+            }
+          ],
+          conflicts: [],
+          recommendations: [
+            {
+              sourceNodeId: "react",
+              nodeId: "vite",
+              relationship: "RecommendedWith"
+            }
+          ]
+        },
+        findings: [
+          {
+            id: "missing-auth",
+            title: "Missing authentication",
+            summary: "Authentication middleware is not configured.",
+            severity: "High",
+            risk: "High",
+            remediation: {
+              title: "Configure authentication",
+              summary: "Add authentication middleware to the host pipeline."
+            },
+            evidence: ["src/Api/Program.cs"]
+          }
+        ]
+      };
+    },
+    async runComplianceEvaluation() {
+      return {
+        summaries: [
+          {
+            regulationId: "pci-dss",
+            regulationTitle: "PCI DSS",
+            scorePercentage: 60,
+            coveredControls: 3,
+            totalControls: 5
+          }
+        ],
+        findings: [
+          {
+            id: "pci-logging",
+            title: "Audit logging gap",
+            summary: "Audit logging coverage is incomplete.",
+            severity: "Medium",
+            risk: "Medium",
+            remediation: {
+              title: "Expand audit logging",
+              summary: "Capture payment authorization and admin actions."
+            },
+            evidence: ["src/Infrastructure/Payments/GatewayClient.cs"]
+          }
+        ]
+      };
+    },
+    async getProjectSelection() {
+      return {
+        frontend: "react",
+        backend: "aspnet-core",
+        architecturePattern: "clean-architecture",
+        ciCd: ["github-actions"],
+        infrastructure: ["docker"],
+        complianceTargets: ["pci-dss"]
+      };
+    },
+    async runProjectGeneration() {
+      return {
+        templateIds: ["frontend-react", "backend-aspnet-core"],
+        generatedArtifacts: [
+          {
+            id: "docs-readme-md",
+            title: "Documentation Layout",
+            kind: "Documentation",
+            relativePath: "docs/README.md"
+          }
+        ],
+        files: []
+      };
+    },
+    async runReportGeneration() {
+      return {
+        reportArtifacts: [
+          {
+            id: "architecture-report-md",
+            title: "architecture-report",
+            format: "Markdown",
+            relativePath: "reports/architecture-report.md"
+          }
+        ],
+        files: [],
+        pdfFallbackUsed: true
+      };
+    },
+    async getAiInstructionContext() {
+      return {
+        projectName: "Fintech Platform",
+        targetKind: "AnalyzedRepository",
+        projectSelection: {
+          frontend: "react",
+          backend: "aspnet-core",
+          architecturePattern: "clean-architecture",
+          ciCd: ["github-actions"],
+          infrastructure: ["docker"],
+          complianceTargets: ["pci-dss"]
+        },
+        standards: [],
+        complianceSummaries: [],
+        findings: []
+      };
+    },
+    async runAiInstructionGeneration() {
+      return {
+        generatedArtifacts: [
+          {
+            id: "agents-md",
+            title: "AGENTS.md",
+            kind: "AiInstructions",
+            relativePath: "AGENTS.md"
+          }
+        ],
+        files: []
+      };
+    }
+  };
+
+  const state = await createLiveDashboardState(services);
+
+  assert.equal(state.subtitle, "Live workspace summary for fintech-platform.");
+
+  const architecture = state.sections.find((section) => section.id === "architecture");
+  const compliance = state.sections.find((section) => section.id === "compliance");
+  const reports = state.sections.find((section) => section.id === "reports");
+  const repositoryAnalysis = state.sections.find((section) => section.id === "repository-analysis");
+
+  assert.ok(architecture);
+  assert.ok(compliance);
+  assert.ok(reports);
+  assert.ok(repositoryAnalysis);
+  assert.ok(architecture.cards.some((card) => card.title === "Target Pattern" && card.value === "clean-architecture"));
+  assert.ok(architecture.panels.some((panel) => panel.items.some((item) => item.includes("React"))));
+  assert.ok(compliance.cards.some((card) => card.title === "PCI DSS" && card.value === "60%"));
+  assert.ok(compliance.panels.some((panel) => panel.items.some((item) => item.includes("Audit logging gap"))));
+  assert.ok(reports.panels.some((panel) => panel.items.some((item) => item.includes("reports/architecture-report.md"))));
+  assert.ok(reports.panels.some((panel) => panel.items.some((item) => item.includes("AGENTS.md"))));
+  assert.ok(
+    repositoryAnalysis.panels.some((panel) => panel.items.some((item) => item.includes("React (Framework)")))
+  );
+  assert.ok(
+    repositoryAnalysis.panels.some((panel) => panel.items.some((item) => item.includes("Financial data")))
+  );
+});
+
+test("live dashboard state returns an explicit empty state when no workspace is available", async () => {
+  let serviceCalls = 0;
+  const state = await createLiveDashboardState({
+    getWorkspaceFolder() {
+      return undefined;
+    },
+    async runRepositoryAnalysis() {
+      serviceCalls += 1;
+      return { signals: [], sensitiveData: [] };
+    }
+  });
+
+  assert.equal(serviceCalls, 0);
+  assert.equal(state.subtitle, "Open a workspace folder to load live Architecture Studio data.");
+
+  const architecture = state.sections.find((section) => section.id === "architecture");
+  const standards = state.sections.find((section) => section.id === "standards");
+  const repositoryAnalysis = state.sections.find((section) => section.id === "repository-analysis");
+
+  assert.ok(architecture);
+  assert.ok(standards);
+  assert.ok(repositoryAnalysis);
+  assert.ok(architecture.panels.some((panel) => panel.items.some((item) => item.includes("Open a workspace folder"))));
+  assert.ok(standards.panels.some((panel) => panel.items.some((item) => item.includes("Open a workspace folder"))));
+  assert.ok(
+    repositoryAnalysis.panels.some((panel) => panel.items.some((item) => item.includes("Open a workspace folder")))
+  );
+});

--- a/test/dashboard/dashboardState.test.ts
+++ b/test/dashboard/dashboardState.test.ts
@@ -3,12 +3,15 @@ import test from "node:test";
 
 import {
   createDashboardState,
-  createPlaceholderSharedContractPayload,
+  createEmptySharedContractPayload,
+  createSampleSharedContractPayload,
   isDashboardWebviewMessage
 } from "../../src/dashboard/dashboardState";
 
-test("dashboard state exposes the required top-level sections with placeholder contract-backed content", () => {
-  const state = createDashboardState();
+test("dashboard state exposes the required top-level sections with explicit empty-state content", () => {
+  const state = createDashboardState(createEmptySharedContractPayload(), {
+    hasWorkspace: false
+  });
 
   assert.deepEqual(
     state.sections.map((section) => section.title),
@@ -21,15 +24,15 @@ test("dashboard state exposes the required top-level sections with placeholder c
   assert.ok(compliance);
   assert.ok(repositoryAnalysis);
   assert.ok(compliance.cards.length > 0, "Expected compliance summary cards.");
-  assert.ok(compliance.panels.some((panel) => panel.items.length > 0), "Expected compliance finding panels.");
+  assert.ok(compliance.panels.some((panel) => panel.items.some((item) => item.includes("Open a workspace folder"))));
   assert.ok(
-    repositoryAnalysis.panels.some((panel) => panel.items.length > 0),
-    "Expected repository analysis placeholder panels."
+    repositoryAnalysis.panels.some((panel) => panel.items.some((item) => item.includes("Open a workspace folder"))),
+    "Expected explicit repository-analysis empty-state panels."
   );
 });
 
 test("dashboard state can project live shared-contract payloads into compliance and report sections", () => {
-  const payload = createPlaceholderSharedContractPayload({
+  const payload = createSampleSharedContractPayload({
     complianceSummaries: [
       {
         regulationId: "hipaa",
@@ -54,7 +57,10 @@ test("dashboard state can project live shared-contract payloads into compliance 
       }
     ]
   });
-  const state = createDashboardState(payload);
+  const state = createDashboardState(payload, {
+    hasWorkspace: true,
+    workspaceLabel: "fintech-platform"
+  });
   const compliance = state.sections.find((section) => section.id === "compliance");
   const reports = state.sections.find((section) => section.id === "reports");
 
@@ -66,7 +72,9 @@ test("dashboard state can project live shared-contract payloads into compliance 
 });
 
 test("dashboard state can surface external package load status in a user-visible panel", () => {
-  const state = createDashboardState(undefined, {
+  const state = createDashboardState(createSampleSharedContractPayload(), {
+    hasWorkspace: true,
+    workspaceLabel: "fintech-platform",
     externalPackageStatuses: [
       {
         packageId: "aws-architecture-pack",


### PR DESCRIPTION
﻿## Summary
- replace the dashboard default sample state with a live workspace snapshot and explicit empty states
- refresh dashboard state after dashboard-triggered commands and guard async refreshes from stale overwrites
- add dashboard snapshot tests plus updated user/developer docs and a screenshot asset

## Validation
- npm run verify
- dotnet test core/ArchitectureStudio.sln
- npm run package:extension

Closes #21
