### PR TITLE
Add PDF report export

### DIFF
--- a/changelog/2026-03-12-issue-22-pdf-export.md
+++ b/changelog/2026-03-12-issue-22-pdf-export.md
@@ -1,0 +1,6 @@
+# Issue 22 PDF Export
+
+- replaced the report engine PDF fallback markdown file with a deterministic PDF artifact at `reports/architecture-report.pdf`
+- added a built-in C# PDF renderer that avoids external services and native PDF dependencies
+- expanded tests to cover PDF artifact generation in the report engine, smoke fixture, and command output path
+- updated report-generation documentation and command-surface text to reflect real PDF export behavior

--- a/core/ArchitectureStudio.Core.Tests/ReportGenerationEngineTests.cs
+++ b/core/ArchitectureStudio.Core.Tests/ReportGenerationEngineTests.cs
@@ -3,7 +3,7 @@ namespace ArchitectureStudio.Core.Tests;
 public sealed class ReportGenerationEngineTests
 {
     [Fact]
-    public void Report_generation_creates_required_export_formats_named_docs_and_pdf_fallback()
+    public void Report_generation_creates_required_export_formats_named_docs_and_a_pdf_artifact()
     {
         var engine = new ReportGenerationEngine();
         var request = new ReportGenerationRequest(
@@ -43,25 +43,32 @@ public sealed class ReportGenerationEngineTests
             "reports/security-policy.md",
             "reports/incident-response.md",
             "reports/architecture.md",
-            "reports/pdf-fallback.md"
+            "reports/architecture-report.pdf"
         })
         {
             Assert.Contains(requiredPath, paths);
         }
 
         Assert.Contains(result.ReportArtifacts, artifact => artifact.Format == ArtifactFormat.Markdown);
+        Assert.Contains(result.ReportArtifacts, artifact => artifact.Format == ArtifactFormat.Pdf);
         Assert.Contains(result.ReportArtifacts, artifact => artifact.Format == ArtifactFormat.Json);
         Assert.Contains(result.ReportArtifacts, artifact => artifact.Format == ArtifactFormat.Sarif);
-        Assert.True(result.PdfFallbackUsed);
+        Assert.False(result.PdfFallbackUsed);
 
         var jsonReport = result.Files.Single(file => file.RelativePath == "reports/compliance-report.json").Content;
         var sarifReport = result.Files.Single(file => file.RelativePath == "reports/findings.sarif").Content;
+        var pdfReport = result.Files.Single(file => file.RelativePath == "reports/architecture-report.pdf").Content;
 
         Assert.Contains("\"scorePercentage\": 72", jsonReport, StringComparison.Ordinal);
         Assert.Contains("\"remediation\"", jsonReport, StringComparison.Ordinal);
         Assert.Contains("\"evidence\"", jsonReport, StringComparison.Ordinal);
         Assert.Contains("\"level\": \"warning\"", sarifReport, StringComparison.Ordinal);
         Assert.Contains("Implement audit logging", sarifReport, StringComparison.Ordinal);
+        Assert.Contains("%PDF-1.4", pdfReport, StringComparison.Ordinal);
+        Assert.Contains("Architecture Studio Architecture Report", pdfReport, StringComparison.Ordinal);
+        Assert.Contains("HIPAA: 72%", pdfReport, StringComparison.Ordinal);
+        Assert.Contains("HIPAA missing control: Audit Logging", pdfReport, StringComparison.Ordinal);
+        Assert.Contains("src/Web/appsettings.json", pdfReport, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/core/ArchitectureStudio.Core.Tests/SmokeFixtureTests.cs
+++ b/core/ArchitectureStudio.Core.Tests/SmokeFixtureTests.cs
@@ -31,8 +31,10 @@ public sealed class SmokeFixtureTests
                 Findings: compliance.Findings));
 
         var complianceJson = reports.Files.Single(file => file.RelativePath == "reports/compliance-report.json").Content;
+        var pdfReport = reports.Files.Single(file => file.RelativePath == "reports/architecture-report.pdf").Content;
         Assert.Contains("\"projectName\": \"Fintech Platform\"", complianceJson, StringComparison.Ordinal);
         Assert.Contains("\"regulationId\": \"pci-dss\"", complianceJson, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(reports.Files, file => file.RelativePath == "reports/findings.sarif");
+        Assert.Contains("%PDF-1.4", pdfReport, StringComparison.Ordinal);
     }
 }

--- a/core/ArchitectureStudio.Core/Reporting/ReportGenerationEngine.cs
+++ b/core/ArchitectureStudio.Core/Reporting/ReportGenerationEngine.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text;
 
 namespace ArchitectureStudio.Core;
 
@@ -50,15 +51,16 @@ public sealed class ReportGenerationEngine
                 Format: ArtifactFormat.Markdown,
                 Content: BuildArchitectureDocumentMarkdown(request)),
             new GeneratedReportFile(
-                RelativePath: $"{exportRoot}/pdf-fallback.md",
-                Format: ArtifactFormat.Markdown,
-                Content: BuildPdfFallbackMarkdown())
+                RelativePath: $"{exportRoot}/architecture-report.pdf",
+                Format: ArtifactFormat.Pdf,
+                Content: BuildPdfReport(request))
         }
         .OrderBy(static file => file.RelativePath, StringComparer.Ordinal)
         .ToArray();
 
         var reportArtifacts = files
             .Where(static file => file.RelativePath.EndsWith("architecture-report.md", StringComparison.OrdinalIgnoreCase)
+                || file.RelativePath.EndsWith("architecture-report.pdf", StringComparison.OrdinalIgnoreCase)
                 || file.RelativePath.EndsWith("compliance-report.json", StringComparison.OrdinalIgnoreCase)
                 || file.RelativePath.EndsWith("findings.sarif", StringComparison.OrdinalIgnoreCase))
             .Select(file => new ReportArtifact(
@@ -72,7 +74,7 @@ public sealed class ReportGenerationEngine
         return new ReportGenerationResult(
             ReportArtifacts: reportArtifacts,
             Files: files,
-            PdfFallbackUsed: true);
+            PdfFallbackUsed: false);
     }
 
     private static string BuildArchitectureMarkdown(ReportGenerationRequest request)
@@ -199,15 +201,202 @@ Project: {request.ProjectName}
 """;
     }
 
-    private static string BuildPdfFallbackMarkdown()
+    private static string BuildPdfReport(ReportGenerationRequest request)
     {
-        return """
-# PDF Fallback
+        var lines = BuildPdfLines(request);
+        return BuildPdfDocument(lines);
+    }
 
-PDF report generation is not implemented yet.
+    private static IReadOnlyList<string> BuildPdfLines(ReportGenerationRequest request)
+    {
+        var lines = new List<string>
+        {
+            $"{request.ProjectName} Architecture Report",
+            string.Empty,
+            "Compliance Score Summary"
+        };
 
-Use the generated Markdown reports as the documented fallback export path.
-""";
+        if (request.ComplianceSummaries.Count == 0)
+        {
+            lines.Add("- No compliance summaries were generated.");
+        }
+        else
+        {
+            lines.AddRange(request.ComplianceSummaries.Select(summary =>
+                $"- {summary.RegulationTitle}: {summary.ScorePercentage}% ({summary.CoveredControls}/{summary.TotalControls} controls)"));
+        }
+
+        lines.Add(string.Empty);
+        lines.Add("Findings");
+
+        if (request.Findings.Count == 0)
+        {
+            lines.Add("- No findings were generated.");
+        }
+        else
+        {
+            foreach (var finding in request.Findings)
+            {
+                lines.Add($"- {finding.Severity}: {finding.Title}");
+                lines.Add($"  Summary: {finding.Summary}");
+                lines.Add($"  Remediation: {finding.Remediation.Title} - {finding.Remediation.Summary}");
+                lines.Add(
+                    finding.Evidence is { Count: > 0 }
+                        ? $"  Evidence: {string.Join(", ", finding.Evidence)}"
+                        : "  Evidence: No evidence paths recorded.");
+            }
+        }
+
+        return lines;
+    }
+
+    private static string BuildPdfDocument(IReadOnlyList<string> lines)
+    {
+        const int pageHeight = 792;
+        const int topMargin = 742;
+        const int lineHeight = 16;
+        const int maxLinesPerPage = 40;
+
+        var pagedLines = lines
+            .Chunk(maxLinesPerPage)
+            .Select(static page => page.ToArray())
+            .ToArray();
+
+        if (pagedLines.Length == 0)
+        {
+            pagedLines = [["Architecture Studio Report"]];
+        }
+
+        var objects = new List<string>();
+        var pageObjectNumbers = new List<int>();
+        var nextObjectNumber = 4;
+
+        foreach (var page in pagedLines)
+        {
+            var pageObjectNumber = nextObjectNumber++;
+            var contentObjectNumber = nextObjectNumber++;
+            var contentStream = BuildPdfContentStream(page, topMargin, lineHeight);
+
+            objects.Add(
+                $$"""
+                {{pageObjectNumber}} 0 obj
+                << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 {{pageHeight}}] /Resources << /Font << /F1 3 0 R >> >> /Contents {{contentObjectNumber}} 0 R >>
+                endobj
+                """
+            );
+            objects.Add(
+                $$"""
+                {{contentObjectNumber}} 0 obj
+                << /Length {{contentStream.Length}} >>
+                stream
+                {{contentStream}}
+                endstream
+                endobj
+                """
+            );
+
+            pageObjectNumbers.Add(pageObjectNumber);
+        }
+
+        var pagesObject =
+            $$"""
+            2 0 obj
+            << /Type /Pages /Count {{pageObjectNumbers.Count}} /Kids [{{string.Join(" ", pageObjectNumbers.Select(static number => $"{number} 0 R"))}}] >>
+            endobj
+            """;
+
+        objects.Insert(0, pagesObject);
+        objects.Insert(0, """
+            1 0 obj
+            << /Type /Catalog /Pages 2 0 R >>
+            endobj
+            """);
+        objects.Insert(2, """
+            3 0 obj
+            << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+            endobj
+            """);
+
+        var builder = new StringBuilder();
+        builder.Append("%PDF-1.4\n");
+
+        var xrefOffsets = new List<int> { 0 };
+        foreach (var pdfObject in objects)
+        {
+            xrefOffsets.Add(builder.Length);
+            builder.Append(pdfObject);
+            builder.Append('\n');
+        }
+
+        var xrefStart = builder.Length;
+        builder.Append("xref\n");
+        builder.Append($"0 {xrefOffsets.Count}\n");
+        builder.Append("0000000000 65535 f \n");
+
+        foreach (var offset in xrefOffsets.Skip(1))
+        {
+            builder.Append($"{offset:D10} 00000 n \n");
+        }
+
+        builder.Append("trailer\n");
+        builder.Append($"<< /Size {xrefOffsets.Count} /Root 1 0 R >>\n");
+        builder.Append("startxref\n");
+        builder.Append(xrefStart);
+        builder.Append("\n%%EOF");
+
+        return builder.ToString();
+    }
+
+    private static string BuildPdfContentStream(IReadOnlyList<string> lines, int topMargin, int lineHeight)
+    {
+        var builder = new StringBuilder();
+        builder.Append("BT\n");
+        builder.Append("/F1 12 Tf\n");
+        builder.Append($"{lineHeight} TL\n");
+        builder.Append($"50 {topMargin} Td\n");
+
+        var firstLine = true;
+        foreach (var line in lines)
+        {
+            if (!firstLine)
+            {
+                builder.Append("T*\n");
+            }
+
+            builder.Append('(');
+            builder.Append(EscapePdfText(line));
+            builder.Append(") Tj\n");
+            firstLine = false;
+        }
+
+        builder.Append("ET");
+        return builder.ToString();
+    }
+
+    private static string EscapePdfText(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+
+        foreach (var character in value)
+        {
+            switch (character)
+            {
+                case '\\':
+                    builder.Append("\\\\");
+                    break;
+                case '(':
+                    builder.Append("\\(");
+                    break;
+                case ')':
+                    builder.Append("\\)");
+                    break;
+                default:
+                    builder.Append(character is >= ' ' and <= '~' ? character : '?');
+                    break;
+            }
+        }
+
+        return builder.ToString();
     }
 
     private static string MapSarifLevel(SeverityLevel severity)

--- a/docs/developer/command-surface.md
+++ b/docs/developer/command-surface.md
@@ -17,7 +17,7 @@ This document defines the stable command entry points exposed by the VS Code ext
 | `architectureStudio.validateRegulations` | `Architecture Studio: Validate Regulations` | `./handlers/validateRegulationsHandler` | Resolves the active workspace, invokes the compliance service boundary, and reports regulation score summaries plus finding counts |
 | `architectureStudio.generateArchitecture` | `Architecture Studio: Generate Architecture` | `./handlers/generateArchitectureHandler` | Resolves the active workspace, invokes the C# technology-graph and architecture-validation path through the core CLI bridge, and reports selected-node, recommendation, and finding counts |
 | `architectureStudio.generateProject` | `Architecture Studio: Generate Project` | `./handlers/generateProjectHandler` | Consumes a selected project profile, invokes the generation service boundary, and reports generated artifact counts plus the applied template set |
-| `architectureStudio.generateReports` | `Architecture Studio: Generate Reports` | `./handlers/generateReportsHandler` | Resolves the active workspace, invokes the report-generation service boundary, and reports export counts plus PDF fallback state |
+| `architectureStudio.generateReports` | `Architecture Studio: Generate Reports` | `./handlers/generateReportsHandler` | Resolves the active workspace, invokes the report-generation service boundary, and reports export counts plus PDF export status |
 | `architectureStudio.generateAiInstructions` | `Architecture Studio: Generate AI Instructions` | `./handlers/generateAiInstructionsHandler` | Resolves AI-instruction context, invokes the instruction-generation service boundary, and reports whether `AGENTS.md` plus related guidance were generated |
 
 ## Design Notes

--- a/docs/developer/release-readiness.md
+++ b/docs/developer/release-readiness.md
@@ -46,6 +46,7 @@ It is used to validate an end-to-end path across:
 - repository analysis
 - compliance evaluation
 - report generation
+- PDF report export
 
 The smoke test is implemented in:
 

--- a/docs/developer/report-generation.md
+++ b/docs/developer/report-generation.md
@@ -7,9 +7,9 @@ Issue `#11` adds the first reporting engine for Architecture Studio. The engine 
 The story delivers:
 
 - Markdown, JSON, and SARIF report generation
+- deterministic PDF report generation
 - named supporting documentation files
 - deterministic export paths under `reports/`
-- an explicit PDF fallback that does not break generation
 
 ## Engine Files
 
@@ -21,20 +21,22 @@ The story delivers:
 Current generated files include:
 
 - `reports/architecture-report.md`
+- `reports/architecture-report.pdf`
 - `reports/compliance-report.json`
 - `reports/findings.sarif`
 - `reports/engineering-playbook.md`
 - `reports/security-policy.md`
 - `reports/incident-response.md`
 - `reports/architecture.md`
-- `reports/pdf-fallback.md`
 
 ## Format Notes
 
 - Markdown provides human-readable architecture and operational summaries.
+- PDF provides a portable document artifact built from the same architecture, compliance, finding, evidence, and remediation content.
 - JSON preserves stable schema data for automation and downstream tooling.
 - SARIF maps findings into a code-scanning-friendly format with severity and remediation fields.
-- PDF is not implemented in this story; the engine emits `reports/pdf-fallback.md` as the documented fallback path.
+- The PDF renderer is implemented directly in C# and does not rely on external services or native PDF tooling.
+- The current PDF layout is intentionally text-first and deterministic; it favors portability and CI safety over advanced styling.
 
 ## TypeScript Boundary
 
@@ -52,11 +54,11 @@ Issue `#11` is covered by:
 - `core/ArchitectureStudio.Core.Tests/ReportGenerationEngineTests.cs`
   - export formats
   - named docs
-  - PDF fallback
+  - PDF artifact generation
   - deterministic output
 - `test/commands/generateReportsHandler.test.ts`
   - workspace targeting
-  - output reporting
+  - output reporting including PDF export status
   - no-workspace handling
 - `test/reports/reportArtifacts.test.ts`
   - transport and documentation artifacts

--- a/docs/user/report-export.md
+++ b/docs/user/report-export.md
@@ -9,6 +9,7 @@ Architecture Studio can now generate shareable reports and supporting documentat
 The current reporting engine supports:
 
 - Markdown
+- PDF
 - JSON
 - SARIF
 
@@ -27,7 +28,11 @@ The current documented export path is `reports/`.
 
 ## PDF Status
 
-PDF output is not implemented yet. Instead of failing report generation, the engine writes a documented fallback file under `reports/pdf-fallback.md` so the export flow stays usable.
+Architecture Studio now generates a real PDF artifact at:
+
+- `reports/architecture-report.pdf`
+
+The PDF is built from the same architecture, compliance summary, finding, evidence, and remediation content used in the other export formats.
 
 ## Why It Matters
 

--- a/src/commands/handlers/generateReportsHandler.ts
+++ b/src/commands/handlers/generateReportsHandler.ts
@@ -18,7 +18,7 @@ export default (async ({ host, output, services }) => {
   const reportArtifacts = reportResult?.reportArtifacts ?? [];
 
   output.appendLine(`[Architecture Studio] Report artifacts: ${reportArtifacts.length}`);
-  output.appendLine(`[Architecture Studio] PDF fallback: ${reportResult?.pdfFallbackUsed ? "enabled" : "disabled"}`);
+  output.appendLine(`[Architecture Studio] PDF export: ${reportResult?.pdfFallbackUsed ? "fallback" : "generated"}`);
 
   await host.showInformationMessage(
     `Generated ${reportArtifacts.length} report artifacts for ${workspacePath}.`

--- a/test/commands/generateReportsHandler.test.ts
+++ b/test/commands/generateReportsHandler.test.ts
@@ -39,13 +39,19 @@ test("generateReports handler targets the active workspace and reports export co
         evaluatedWorkspacePath = workspacePath;
 
         return {
-          pdfFallbackUsed: true,
+          pdfFallbackUsed: false,
           reportArtifacts: [
             {
               id: "report-architecture-markdown",
               title: "Architecture Report",
               format: "Markdown",
               relativePath: "reports/architecture-report.md"
+            },
+            {
+              id: "report-architecture-pdf",
+              title: "Architecture Report PDF",
+              format: "Pdf",
+              relativePath: "reports/architecture-report.pdf"
             },
             {
               id: "report-compliance-json",
@@ -69,9 +75,9 @@ test("generateReports handler targets the active workspace and reports export co
   assert.equal(evaluatedWorkspacePath, "C:/code/Playground/ARCHITECTURE_STUDIO");
   assert.equal(errors.length, 0);
   assert.ok(outputLines.some((line) => line.includes("Target workspace: C:/code/Playground/ARCHITECTURE_STUDIO")));
-  assert.ok(outputLines.some((line) => line.includes("Report artifacts: 2")));
-  assert.ok(outputLines.some((line) => line.includes("PDF fallback: enabled")));
-  assert.ok(messages.some((line) => line.includes("Generated 2 report artifacts")));
+  assert.ok(outputLines.some((line) => line.includes("Report artifacts: 3")));
+  assert.ok(outputLines.some((line) => line.includes("PDF export: generated")));
+  assert.ok(messages.some((line) => line.includes("Generated 3 report artifacts")));
 });
 
 test("generateReports handler shows an error when no workspace is open", async () => {


### PR DESCRIPTION
﻿## Summary
- replace the markdown PDF fallback with a deterministic built-in C# PDF artifact
- update report tests, smoke coverage, command output, and docs for real PDF export behavior
- validate the packaged CLI host returns `reports/architecture-report.pdf` with `pdfFallbackUsed: false`

## Validation
- npm run verify
- dotnet test core/ArchitectureStudio.sln
- npm run package:extension
- dotnet core-host/ArchitectureStudio.Cli.dll generate-reports --workspace fixtures/sample-workspaces/fintech-platform

Closes #22
