### PR TITLE
Apply external package contributions at runtime

### DIFF
--- a/changelog/2026-03-12-issue-27-external-package-runtime.md
+++ b/changelog/2026-03-12-issue-27-external-package-runtime.md
@@ -1,0 +1,9 @@
+# Issue 27: External Package Runtime Integration
+
+## Summary
+
+- wired valid external packages into the default C# standards, graph, compliance, and template catalogs
+- updated the default workspace orchestrator to build its engines from the merged runtime catalogs
+- added regression tests proving shipped sample packs affect standards composition, architecture reasoning, compliance evaluation, and project generation
+- removed the unsupported `--stdin` bridge flag so standard-input CLI commands still work through the extension host boundary
+- updated user and developer external package documentation to reflect runtime behavior instead of discovery-only behavior

--- a/core/ArchitectureStudio.Core.Tests/ExternalPackageRuntimeIntegrationTests.cs
+++ b/core/ArchitectureStudio.Core.Tests/ExternalPackageRuntimeIntegrationTests.cs
@@ -1,0 +1,90 @@
+namespace ArchitectureStudio.Core.Tests;
+
+public sealed class ExternalPackageRuntimeIntegrationTests
+{
+    [Fact]
+    public void Default_catalogs_include_external_package_contributions()
+    {
+        var standardsCatalog = StandardsCatalog.CreateDefault();
+        Assert.Contains(standardsCatalog.Packages, package => package.Id == "aws-architecture-pack");
+        Assert.Contains(standardsCatalog.Standards, standard => standard.Id == "aws-well-architected");
+
+        var complianceCatalog = ComplianceCatalog.CreateDefault();
+        Assert.Contains("segregation-of-duties", complianceCatalog.ControlsById.Keys);
+        Assert.Contains(complianceCatalog.Regulations, regulation => regulation.Id == "operational-resilience");
+
+        var templateCatalog = ProjectTemplateCatalog.CreateDefault();
+        Assert.Contains(templateCatalog.Templates, template => template.Id == "infra-aws-reference-stack");
+        Assert.Contains(templateCatalog.Templates, template => template.Id == "project-kafka-eventing");
+
+        var graph = TechnologyGraphCatalog.CreateDefault().Graph;
+        Assert.Contains(graph.Nodes, node => node.Id == "aws-lambda");
+        Assert.Contains(graph.Nodes, node => node.Id == "schema-registry");
+    }
+
+    [Fact]
+    public void Default_runtime_uses_external_package_contributions_across_engines()
+    {
+        var standardsEngine = new StandardsCompositionEngine(StandardsCatalog.CreateDefault());
+        var standardsResult = standardsEngine.Compose(
+            new StandardsCompositionRequest(
+                ProjectSelection: new StandardsProjectSelection(
+                    Frontend: "react",
+                    Backend: "aspnet-core",
+                    ArchitecturePattern: "clean-architecture",
+                    CiCd: ["github-actions"],
+                    Infrastructure: ["aws"],
+                    AdditionalSelections: [])));
+
+        var awsStandard = Assert.Single(standardsResult.Standards, standard => standard.Definition.Id == "aws-well-architected");
+        Assert.Equal("aws-architecture-pack", awsStandard.Source.PackageId);
+
+        var graphEngine = new TechnologyGraphEngine(TechnologyGraphCatalog.CreateDefault());
+        var graphEvaluation = graphEngine.Evaluate(new TechnologyStackSelection(["aws-lambda", "kafka"]));
+        Assert.Contains(graphEvaluation.Recommendations, recommendation => recommendation.NodeId == "cloudwatch");
+        Assert.Contains(graphEvaluation.Recommendations, recommendation => recommendation.NodeId == "schema-registry");
+
+        var complianceEngine = new ComplianceEngine(ComplianceCatalog.CreateDefault());
+        var complianceResult = complianceEngine.Evaluate(
+            new ComplianceEvaluationRequest(
+                SystemCharacteristics: ["payments"],
+                RepositoryAnalysis: new RepositoryAnalysisResult(
+                    Signals:
+                    [
+                        new RepositorySignal(
+                            Id: "kafka",
+                            Label: "Kafka",
+                            Category: RepositorySignalCategory.Infrastructure,
+                            Confidence: 0.95,
+                            Evidence: ["Detected Kafka topology."],
+                            AffectedPaths: ["docs/eventing/kafka-topology.md"])
+                    ],
+                    SensitiveData:
+                    [
+                        new SensitiveDataClassification(
+                            Category: SensitiveDataCategory.Financial,
+                            Confidence: 0.94,
+                            Evidence: ["Financial data indicator matched in ledger.json."],
+                            AffectedPaths: ["data/ledger.json"])
+                    ]),
+                ImplementedControlIds: []));
+
+        Assert.Contains(complianceResult.Summaries, summary => summary.RegulationId == "operational-resilience");
+        Assert.Contains(complianceResult.Findings, finding => finding.Id == "missing-control-operational-resilience-segregation-of-duties");
+
+        var orchestrator = StudioWorkspaceOrchestrator.CreateDefault();
+        var projectResult = orchestrator.GenerateProject(
+            new ProjectSelectionProfile(
+                Frontend: "react",
+                Backend: "aspnet-core",
+                ArchitecturePattern: "event-driven",
+                CiCd: ["github-actions"],
+                Infrastructure: ["aws"],
+                ComplianceTargets: []));
+
+        Assert.Contains(projectResult.TemplateIds, templateId => templateId == "infra-aws-reference-stack");
+        Assert.Contains(projectResult.TemplateIds, templateId => templateId == "project-kafka-eventing");
+        Assert.Contains(projectResult.GeneratedArtifacts, artifact => artifact.RelativePath == "infra/aws/README.md");
+        Assert.Contains(projectResult.GeneratedArtifacts, artifact => artifact.RelativePath == "docs/eventing/kafka-topology.md");
+    }
+}

--- a/core/ArchitectureStudio.Core/Compliance/ComplianceCatalog.cs
+++ b/core/ArchitectureStudio.Core/Compliance/ComplianceCatalog.cs
@@ -36,6 +36,11 @@ public sealed class ComplianceCatalog
 
     public static ComplianceCatalog CreateDefault()
     {
+        return StudioRuntimeCatalogFactory.CreateDefault().ComplianceCatalog;
+    }
+
+    internal static ComplianceCatalog CreateBuiltIn()
+    {
         var baseDirectory = AppContext.BaseDirectory;
         var controlsDirectory = Path.Combine(baseDirectory, RelativeControlsDirectory);
         var regulationsDirectory = Path.Combine(baseDirectory, RelativeRegulationsDirectory);
@@ -63,9 +68,19 @@ public sealed class ComplianceCatalog
 
         ValidateCatalog(controls, regulations);
 
-        return new ComplianceCatalog(
-            controls.ToDictionary(static control => control.Id, StringComparer.OrdinalIgnoreCase),
-            regulations);
+        return CreateCatalog(controls, regulations);
+    }
+
+    internal ComplianceCatalog WithExternalPackage(ExternalPackage package)
+    {
+        var controls = package.Contributions.Controls
+            .SelectMany(reference => ReadControls(reference.FullPath))
+            .ToArray();
+        var regulations = package.Contributions.Regulations
+            .SelectMany(reference => ReadRegulations(reference.FullPath))
+            .ToArray();
+
+        return WithDefinitions(controls, regulations);
     }
 
     private static IReadOnlyList<ComplianceControlDefinition> ReadControls(string path)
@@ -76,6 +91,28 @@ public sealed class ComplianceCatalog
     private static IReadOnlyList<ComplianceRegulationDefinition> ReadRegulations(string path)
     {
         return ReadJsonValues<ComplianceRegulationDefinition>(path);
+    }
+
+    private ComplianceCatalog WithDefinitions(
+        IReadOnlyList<ComplianceControlDefinition> controls,
+        IReadOnlyList<ComplianceRegulationDefinition> regulations)
+    {
+        var mergedControls = _controlsById
+            .Values
+            .Concat(controls)
+            .GroupBy(static control => control.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.Last())
+            .OrderBy(static control => control.Id, StringComparer.Ordinal)
+            .ToArray();
+        var mergedRegulations = _regulations
+            .Concat(regulations)
+            .GroupBy(static regulation => regulation.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.Last())
+            .OrderBy(static regulation => regulation.Title, StringComparer.Ordinal)
+            .ThenBy(static regulation => regulation.Id, StringComparer.Ordinal)
+            .ToArray();
+
+        return CreateCatalog(mergedControls, mergedRegulations);
     }
 
     private static IReadOnlyList<T> ReadJsonValues<T>(string path)
@@ -126,5 +163,16 @@ public sealed class ComplianceCatalog
                 }
             }
         }
+    }
+
+    private static ComplianceCatalog CreateCatalog(
+        IReadOnlyList<ComplianceControlDefinition> controls,
+        IReadOnlyList<ComplianceRegulationDefinition> regulations)
+    {
+        ValidateCatalog(controls, regulations);
+
+        return new ComplianceCatalog(
+            controls.ToDictionary(static control => control.Id, StringComparer.OrdinalIgnoreCase),
+            regulations);
     }
 }

--- a/core/ArchitectureStudio.Core/Generation/ProjectTemplateCatalog.cs
+++ b/core/ArchitectureStudio.Core/Generation/ProjectTemplateCatalog.cs
@@ -29,6 +29,11 @@ public sealed class ProjectTemplateCatalog
 
     public static ProjectTemplateCatalog CreateDefault()
     {
+        return StudioRuntimeCatalogFactory.CreateDefault().ProjectTemplateCatalog;
+    }
+
+    internal static ProjectTemplateCatalog CreateBuiltIn()
+    {
         var templatesDirectory = Path.Combine(AppContext.BaseDirectory, RelativeTemplatesDirectory);
         if (!Directory.Exists(templatesDirectory))
         {
@@ -46,11 +51,33 @@ public sealed class ProjectTemplateCatalog
         return new ProjectTemplateCatalog(templates);
     }
 
+    internal ProjectTemplateCatalog WithExternalPackage(ExternalPackage package)
+    {
+        var templates = package.Contributions.Templates
+            .Select(reference => ReadTemplate(reference.FullPath))
+            .ToArray();
+
+        return WithTemplates(templates);
+    }
+
     private static ProjectTemplateDefinition ReadTemplate(string path)
     {
         using var stream = File.OpenRead(path);
         return JsonSerializer.Deserialize<ProjectTemplateDefinition>(stream, SerializerOptions)
             ?? throw new InvalidOperationException($"Template '{path}' could not be deserialized.");
+    }
+
+    private ProjectTemplateCatalog WithTemplates(IReadOnlyList<ProjectTemplateDefinition> templates)
+    {
+        var mergedTemplates = _templates
+            .Concat(templates)
+            .GroupBy(static template => template.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.Last())
+            .OrderBy(static template => template.Id, StringComparer.Ordinal)
+            .ToArray();
+
+        ValidateTemplates(mergedTemplates);
+        return new ProjectTemplateCatalog(mergedTemplates);
     }
 
     private static void ValidateTemplates(IReadOnlyList<ProjectTemplateDefinition> templates)

--- a/core/ArchitectureStudio.Core/Graph/TechnologyGraphCatalog.cs
+++ b/core/ArchitectureStudio.Core/Graph/TechnologyGraphCatalog.cs
@@ -18,37 +18,65 @@ public sealed class TechnologyGraphCatalog
 
     public static TechnologyGraphCatalog CreateDefault()
     {
+        return StudioRuntimeCatalogFactory.CreateDefault().TechnologyGraphCatalog;
+    }
+
+    internal static TechnologyGraphCatalog CreateBuiltIn()
+    {
         var datasetDirectory = Path.Combine(AppContext.BaseDirectory, RelativeDatasetDirectory);
         if (!Directory.Exists(datasetDirectory))
         {
             throw new InvalidOperationException($"Graph dataset directory '{datasetDirectory}' was not found.");
         }
 
-        var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(UnderscoredNamingConvention.Instance)
-            .IgnoreUnmatchedProperties()
-            .Build();
-
         var yamlFiles = Directory.GetFiles(datasetDirectory, "*.yml", SearchOption.TopDirectoryOnly)
             .OrderBy(static path => path, StringComparer.Ordinal)
             .ToArray();
 
-        var datasetNodes = yamlFiles
-            .SelectMany(path =>
-            {
-                using var reader = File.OpenText(path);
-                var document = deserializer.Deserialize<TechnologyGraphDatasetDocument>(reader);
-                return document.Nodes ?? [];
-            })
-            .ToArray();
+        return new TechnologyGraphCatalog(LoadGraph(yamlFiles));
+    }
 
-        var nodes = datasetNodes
-            .Select(static node => new GraphNodeDefinition(node.Id, node.Label, node.Category))
+    internal TechnologyGraphCatalog WithExternalPackage(ExternalPackage package)
+    {
+        if (package.Contributions.GraphDatasets.Count == 0)
+        {
+            return this;
+        }
+
+        var externalGraph = LoadGraph(package.Contributions.GraphDatasets.Select(static reference => reference.FullPath));
+        var nodes = _graph.Nodes
+            .Concat(externalGraph.Nodes)
+            .GroupBy(static node => node.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.Last())
             .OrderBy(static node => node.Category)
             .ThenBy(static node => node.Label, StringComparer.Ordinal)
             .ThenBy(static node => node.Id, StringComparer.Ordinal)
             .ToArray();
+        var edges = _graph.Edges
+            .Concat(externalGraph.Edges)
+            .Distinct()
+            .OrderBy(static edge => edge.SourceId, StringComparer.Ordinal)
+            .ThenBy(static edge => edge.TargetId, StringComparer.Ordinal)
+            .ThenBy(static edge => edge.Relationship)
+            .ToArray();
 
+        return new TechnologyGraphCatalog(new TechnologyGraph(nodes, edges));
+    }
+
+    private static TechnologyGraph LoadGraph(IEnumerable<string> yamlFiles)
+    {
+        var datasetNodes = yamlFiles
+            .SelectMany(ReadDatasetNodes)
+            .ToArray();
+
+        var nodes = datasetNodes
+            .Select(static node => new GraphNodeDefinition(node.Id, node.Label, node.Category))
+            .GroupBy(static node => node.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.Last())
+            .OrderBy(static node => node.Category)
+            .ThenBy(static node => node.Label, StringComparer.Ordinal)
+            .ThenBy(static node => node.Id, StringComparer.Ordinal)
+            .ToArray();
         var edges = datasetNodes
             .SelectMany(CreateEdges)
             .Distinct()
@@ -57,7 +85,19 @@ public sealed class TechnologyGraphCatalog
             .ThenBy(static edge => edge.Relationship)
             .ToArray();
 
-        return new TechnologyGraphCatalog(new TechnologyGraph(nodes, edges));
+        return new TechnologyGraph(nodes, edges);
+    }
+
+    private static IReadOnlyList<TechnologyGraphDatasetNode> ReadDatasetNodes(string path)
+    {
+        var deserializer = new DeserializerBuilder()
+            .WithNamingConvention(UnderscoredNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+        using var reader = File.OpenText(path);
+        var document = deserializer.Deserialize<TechnologyGraphDatasetDocument>(reader);
+        return document.Nodes ?? [];
     }
 
     private static IEnumerable<GraphEdgeDefinition> CreateEdges(TechnologyGraphDatasetNode node)

--- a/core/ArchitectureStudio.Core/Runtime/StudioRuntimeCatalogFactory.cs
+++ b/core/ArchitectureStudio.Core/Runtime/StudioRuntimeCatalogFactory.cs
@@ -1,0 +1,37 @@
+namespace ArchitectureStudio.Core;
+
+internal sealed record StudioRuntimeCatalogs(
+    StandardsCatalog StandardsCatalog,
+    TechnologyGraphCatalog TechnologyGraphCatalog,
+    ComplianceCatalog ComplianceCatalog,
+    ProjectTemplateCatalog ProjectTemplateCatalog,
+    ExternalPackageDiscoveryResult ExternalPackages);
+
+internal static class StudioRuntimeCatalogFactory
+{
+    private const string RelativePackagesDirectory = "Plugins/Packs";
+
+    public static StudioRuntimeCatalogs CreateDefault()
+    {
+        var discovery = ExternalPackageLoader.Discover(Path.Combine(AppContext.BaseDirectory, RelativePackagesDirectory));
+        var standardsCatalog = StandardsCatalog.CreateBuiltIn();
+        var technologyGraphCatalog = TechnologyGraphCatalog.CreateBuiltIn();
+        var complianceCatalog = ComplianceCatalog.CreateBuiltIn();
+        var projectTemplateCatalog = ProjectTemplateCatalog.CreateBuiltIn();
+
+        foreach (var package in discovery.Packages)
+        {
+            standardsCatalog = standardsCatalog.WithExternalPackage(package);
+            technologyGraphCatalog = technologyGraphCatalog.WithExternalPackage(package);
+            complianceCatalog = complianceCatalog.WithExternalPackage(package);
+            projectTemplateCatalog = projectTemplateCatalog.WithExternalPackage(package);
+        }
+
+        return new StudioRuntimeCatalogs(
+            standardsCatalog,
+            technologyGraphCatalog,
+            complianceCatalog,
+            projectTemplateCatalog,
+            discovery);
+    }
+}

--- a/core/ArchitectureStudio.Core/Standards/StandardsCatalog.cs
+++ b/core/ArchitectureStudio.Core/Standards/StandardsCatalog.cs
@@ -29,6 +29,11 @@ public sealed class StandardsCatalog
 
     public static StandardsCatalog CreateDefault()
     {
+        return StudioRuntimeCatalogFactory.CreateDefault().StandardsCatalog;
+    }
+
+    internal static StandardsCatalog CreateBuiltIn()
+    {
         var assembly = typeof(StandardsCatalog).Assembly;
         using var stream = assembly.GetManifestResourceStream(DefaultSeedResourceName)
             ?? throw new InvalidOperationException($"Embedded standards seed resource '{DefaultSeedResourceName}' was not found.");
@@ -45,5 +50,30 @@ public sealed class StandardsCatalog
             .ToArray();
 
         return new StandardsCatalog(packages);
+    }
+
+    internal StandardsCatalog WithPackages(IEnumerable<StandardsPackage> packages)
+    {
+        var catalog = this;
+
+        foreach (var package in packages)
+        {
+            catalog = catalog.WithPackage(package);
+        }
+
+        return catalog;
+    }
+
+    internal StandardsCatalog WithExternalPackage(ExternalPackage package)
+    {
+        var packages = package.Contributions.StandardsPackages
+            .Select(static reference =>
+            {
+                using var stream = File.OpenRead(reference.FullPath);
+                return StandardsJson.Deserialize<StandardsPackage>(stream);
+            })
+            .ToArray();
+
+        return WithPackages(packages);
     }
 }

--- a/core/ArchitectureStudio.Core/Workspace/StudioWorkspaceOrchestrator.cs
+++ b/core/ArchitectureStudio.Core/Workspace/StudioWorkspaceOrchestrator.cs
@@ -40,12 +40,14 @@ public sealed class StudioWorkspaceOrchestrator
 
     public static StudioWorkspaceOrchestrator CreateDefault()
     {
+        var runtimeCatalogs = StudioRuntimeCatalogFactory.CreateDefault();
+
         return new StudioWorkspaceOrchestrator(
             new RepositoryAnalysisEngine(),
-            new StandardsCompositionEngine(StandardsCatalog.CreateDefault()),
-            new TechnologyGraphEngine(TechnologyGraphCatalog.CreateDefault()),
-            new ComplianceEngine(ComplianceCatalog.CreateDefault()),
-            new ProjectGenerationEngine(ProjectTemplateCatalog.CreateDefault()),
+            new StandardsCompositionEngine(runtimeCatalogs.StandardsCatalog),
+            new TechnologyGraphEngine(runtimeCatalogs.TechnologyGraphCatalog),
+            new ComplianceEngine(runtimeCatalogs.ComplianceCatalog),
+            new ProjectGenerationEngine(runtimeCatalogs.ProjectTemplateCatalog),
             new ReportGenerationEngine(),
             new AiInstructionGenerationEngine());
     }

--- a/docs/developer/external-packages.md
+++ b/docs/developer/external-packages.md
@@ -81,7 +81,26 @@ When a package fails validation:
 
 ## Runtime Surface
 
-The dashboard standards section now surfaces package load status in a user-visible panel. That keeps discovery visible without requiring a debugger or hidden logs.
+Package discovery is now consumed by the default C# runtime, not just surfaced in the dashboard. Valid packs are merged into the active catalogs used by:
+
+- `StandardsCatalog.CreateDefault()`
+- `TechnologyGraphCatalog.CreateDefault()`
+- `ComplianceCatalog.CreateDefault()`
+- `ProjectTemplateCatalog.CreateDefault()`
+- `StudioWorkspaceOrchestrator.CreateDefault()`
+
+The runtime merge path is implemented in:
+
+- `core/ArchitectureStudio.Core/Runtime/StudioRuntimeCatalogFactory.cs`
+
+That means external package content now influences:
+
+- standards composition
+- architecture graph evaluation and recommendations
+- compliance regulation/control matching
+- project and infrastructure generation
+
+The dashboard standards section still surfaces package load status in a user-visible panel. That keeps discovery visible without requiring a debugger or hidden logs.
 
 Status contract:
 
@@ -100,6 +119,7 @@ Contribution kind summaries:
 The story is driven by:
 
 - `core/ArchitectureStudio.Core.Tests/ExternalPackageLoaderTests.cs`
+- `core/ArchitectureStudio.Core.Tests/ExternalPackageRuntimeIntegrationTests.cs`
 - `test/plugins/externalPackageArtifacts.test.ts`
 - `test/dashboard/dashboardState.test.ts`
 
@@ -108,5 +128,6 @@ These tests cover:
 - discovery of required sample packs
 - contribution point validation
 - graceful handling for invalid packages
+- runtime application of standards, graph, compliance, and template contributions
 - dashboard projection of package status
 - presence of docs and manifest artifacts

--- a/docs/user/external-packages.md
+++ b/docs/user/external-packages.md
@@ -32,6 +32,13 @@ When packages are discovered, the dashboard `Standards` section shows:
 
 This makes it easy to tell whether a newly added package is ready before you rely on it in standards composition or generation flows.
 
+Once a package loads successfully, its contributions are used by the runtime automatically. That means external packs can change:
+
+- standards composed by `Architecture Studio: Compose Standards`
+- architecture recommendations produced by `Architecture Studio: Generate Architecture`
+- compliance summaries and findings produced by `Architecture Studio: Validate Regulations`
+- generated project outputs produced by `Architecture Studio: Generate Project`
+
 ## Sample Packs In This Repository
 
 The repository currently includes:
@@ -52,7 +59,8 @@ These examples show how to structure:
 2. Confirm the package includes `architecture-studio.package.json`.
 3. Verify every manifest path points to a real file inside that package folder.
 4. Open the dashboard and check the `External Package Status` panel.
-5. Fix any invalid-package message before depending on the new pack.
+5. Run the command flow that should use the pack, such as standards composition, compliance validation, architecture generation, or project generation.
+6. Fix any invalid-package message before depending on the new pack.
 
 ## Authoring Guidance
 

--- a/src/core/architectureStudioCoreCli.ts
+++ b/src/core/architectureStudioCoreCli.ts
@@ -135,10 +135,6 @@ async function invokeCoreCli<TResult>(
     args.push("--workspace", options.workspacePath);
   }
 
-  if (options.stdinJson) {
-    args.push("--stdin");
-  }
-
   output?.appendLine(`[Architecture Studio] Core CLI command: ${commandName}`);
   const result = await runProcess({
     command: launchPlan.command,

--- a/test/core/architectureStudioCoreCli.test.ts
+++ b/test/core/architectureStudioCoreCli.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createArchitectureStudioCoreCli } from "../../src/core/architectureStudioCoreCli";
+
+test("core CLI bridge sends project generation requests over standard input without an extra stdin flag", async () => {
+  const invocations: {
+    readonly args: readonly string[];
+    readonly stdin?: string;
+  }[] = [];
+  const cli = createArchitectureStudioCoreCli({
+    extensionPath: "C:/code/Playground/ARCHITECTURE_STUDIO",
+    fileExists() {
+      return true;
+    },
+    async runProcess(request) {
+      invocations.push({
+        args: request.args,
+        stdin: request.stdin
+      });
+
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          templateIds: ["infra-aws-reference-stack"],
+          generatedArtifacts: [],
+          files: []
+        }),
+        stderr: ""
+      };
+    }
+  });
+
+  const result = await cli.generateProject({
+    frontend: "react",
+    backend: "aspnet-core",
+    architecturePattern: "event-driven",
+    ciCd: ["github-actions"],
+    infrastructure: ["aws"],
+    complianceTargets: []
+  });
+
+  assert.deepEqual(result.templateIds, ["infra-aws-reference-stack"]);
+  assert.equal(invocations.length, 1);
+  assert.equal(invocations[0].args[1], "generate-project");
+  assert.ok(!invocations[0].args.includes("--stdin"));
+  assert.match(invocations[0].stdin ?? "", /"architecturePattern":"event-driven"/);
+});
+
+test("core CLI bridge sends AI instruction generation requests over standard input without an extra stdin flag", async () => {
+  const invocations: {
+    readonly args: readonly string[];
+    readonly stdin?: string;
+  }[] = [];
+  const cli = createArchitectureStudioCoreCli({
+    extensionPath: "C:/code/Playground/ARCHITECTURE_STUDIO",
+    fileExists() {
+      return true;
+    },
+    async runProcess(request) {
+      invocations.push({
+        args: request.args,
+        stdin: request.stdin
+      });
+
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          generatedArtifacts: [],
+          files: []
+        }),
+        stderr: ""
+      };
+    }
+  });
+
+  await cli.generateAiInstructions({
+    projectName: "Architecture Studio",
+    targetKind: "AnalyzedRepository",
+    projectSelection: {
+      frontend: "react",
+      backend: "aspnet-core",
+      architecturePattern: "clean-architecture",
+      ciCd: ["github-actions"],
+      infrastructure: ["docker"],
+      complianceTargets: ["pci-dss"]
+    },
+    standards: [],
+    complianceSummaries: [],
+    findings: []
+  });
+
+  assert.equal(invocations.length, 1);
+  assert.equal(invocations[0].args[1], "generate-ai-instructions");
+  assert.ok(!invocations[0].args.includes("--stdin"));
+  assert.match(invocations[0].stdin ?? "", /"projectName":"Architecture Studio"/);
+});


### PR DESCRIPTION
﻿## Summary
- merge valid external package contributions into the default C# standards, graph, compliance, and template catalogs
- update the default orchestrator to use the merged runtime catalogs and document that packs now affect runtime outputs
- add runtime integration coverage for external packs and remove the unsupported `--stdin` bridge flag from standard-input CLI commands

## Validation
- dotnet test core/ArchitectureStudio.sln --filter FullyQualifiedName~ExternalPackageRuntimeIntegrationTests
- npm test -- --test test/core/architectureStudioCoreCli.test.ts
- npm run verify
- dotnet test core/ArchitectureStudio.sln
- npm run package:extension
- PowerShell JSON pipe into `dotnet core-host/ArchitectureStudio.Cli.dll generate-project`

Closes #27
