### PR TITLE
Host the dashboard in the activity bar

### DIFF
--- a/changelog/2026-03-12-issue-29-activity-bar-dashboard.md
+++ b/changelog/2026-03-12-issue-29-activity-bar-dashboard.md
@@ -1,0 +1,8 @@
+# Issue 29: Activity Bar Dashboard
+
+## Summary
+
+- added an `Architecture Studio` Activity Bar container with a sidebar-hosted dashboard webview
+- registered a sidebar provider that reuses the existing dashboard HTML, state projection, and typed message bridge
+- changed `Architecture Studio: Open Dashboard` to focus the contributed sidebar view instead of opening a separate panel
+- added manifest, registration, and sidebar-provider regression tests plus user and developer documentation updates

--- a/docs/developer/command-surface.md
+++ b/docs/developer/command-surface.md
@@ -11,7 +11,7 @@ This document defines the stable command entry points exposed by the VS Code ext
 
 | Command ID | Title | Handler Module | Current Behavior |
 | --- | --- | --- | --- |
-| `architectureStudio.openDashboard` | `Architecture Studio: Open Dashboard` | `./handlers/openDashboardHandler` | Routes through the centralized command runtime and opens the live workspace-backed dashboard surface |
+| `architectureStudio.openDashboard` | `Architecture Studio: Open Dashboard` | `./handlers/openDashboardHandler` | Routes through the centralized command runtime and focuses the live workspace-backed sidebar dashboard view |
 | `architectureStudio.composeStandards` | `Architecture Studio: Compose Standards` | `./handlers/composeStandardsHandler` | Resolves the active workspace, invokes the C# standards-composition path through the core CLI bridge, and reports the composed-standard count |
 | `architectureStudio.analyzeRepository` | `Architecture Studio: Analyze Repository` | `./handlers/analyzeRepositoryHandler` | Resolves the active workspace, invokes the repository-analysis service boundary, and reports structured result counts |
 | `architectureStudio.validateRegulations` | `Architecture Studio: Validate Regulations` | `./handlers/validateRegulationsHandler` | Resolves the active workspace, invokes the compliance service boundary, and reports regulation score summaries plus finding counts |

--- a/docs/developer/dashboard-webview.md
+++ b/docs/developer/dashboard-webview.md
@@ -12,9 +12,10 @@ The dashboard webview is the first shared UI shell for Architecture Studio. It g
 
 ## Host And Client Boundary
 
-The extension host owns panel lifecycle and data projection:
+The extension host owns sidebar-view lifecycle and data projection:
 
-- `src/dashboard/dashboardController.ts` manages the single active panel, reopen behavior, and typed message routing
+- `src/dashboard/dashboardSidebarProvider.ts` manages the contributed sidebar webview, focus behavior, visibility refresh, and typed message routing
+- `src/dashboard/registerDashboardSidebar.ts` wires the provider into the contributed `architectureStudio.dashboardView`
 - `src/dashboard/dashboardData.ts` aggregates the live workspace snapshot from the existing command-service engine calls
 - `src/dashboard/dashboardState.ts` projects shared-contract payloads into a dashboard-oriented DTO
 - `src/dashboard/dashboardHtml.ts` renders the initial HTML shell and references the packaged assets
@@ -39,11 +40,12 @@ The bridge is intentionally small. The webview consumes DTOs only and does not k
 
 ## Lifecycle Rules
 
-- only one dashboard panel is active at a time
-- reopening reveals the existing panel instead of creating duplicates
-- disposing the panel clears the message and dispose subscriptions so handlers do not accumulate
-- the controller can post refreshed state when the panel is revealed again
-- dashboard-triggered commands refresh the state after execution so the panel does not keep stale data
+- the dashboard is hosted in a contributed Activity Bar container rather than a free-floating editor panel
+- only one contributed dashboard view is active at a time
+- `Architecture Studio: Open Dashboard` focuses the contributed sidebar view
+- disposing the view clears message and visibility subscriptions so handlers do not accumulate
+- the provider can post refreshed state when the view is shown again
+- dashboard-triggered commands refresh the state after execution so the view does not keep stale data
 - async state refreshes are versioned so older responses do not overwrite newer ones
 
 ## Live Snapshot Model
@@ -71,9 +73,11 @@ Illustrated screenshot asset:
 
 The dashboard test surface now covers:
 
+- manifest contribution for the Activity Bar container and sidebar view
+- sidebar-provider registration wiring
 - required dashboard sections
 - live workspace snapshot projection
 - explicit no-workspace empty states
 - typed message validation
-- panel reuse, dispose/reopen behavior, and post-command refresh
+- sidebar focus, dispose/reopen behavior, and post-command refresh
 - packaged asset and documentation presence

--- a/docs/user/dashboard.md
+++ b/docs/user/dashboard.md
@@ -2,7 +2,7 @@
 
 ## What It Is
 
-The Architecture Studio dashboard is the main workspace surface for the extension. It brings the most important project views together in one place so you do not have to bounce between separate commands just to understand current status.
+The Architecture Studio dashboard is the main workspace surface for the extension. It now lives in the VS Code Activity Bar as its own `Architecture Studio` sidebar entry, so you can keep the tool open like any other first-class workspace view.
 
 The dashboard currently includes:
 
@@ -23,7 +23,7 @@ Each section is intended to give you:
 - a quick summary of current status
 - a focused list of details to review
 - action buttons that route back into the matching extension command
-- deterministic refresh behavior when you reopen the panel or trigger a dashboard action
+- deterministic refresh behavior when you reopen the sidebar or trigger a dashboard action
 
 ## Why It Matters
 
@@ -41,9 +41,10 @@ The compliance section can now render score cards in the same style the product 
 
 The current dashboard story now delivers:
 
+- an Activity Bar entry and sidebar-hosted dashboard view
 - the packaged webview shell and typed message bridge
 - live workspace-backed section content
 - explicit no-workspace and no-data empty states
 - refresh after dashboard-triggered commands
 
-Use the sample fintech fixture or your own workspace to see the live cards and evidence panels populate.
+Use the `Architecture Studio` item in the left sidebar, then run `Architecture Studio: Open Dashboard` any time you want VS Code to focus that view for you. Use the sample fintech fixture or your own workspace to see the live cards and evidence panels populate.

--- a/media/architecture-studio.svg
+++ b/media/architecture-studio.svg
@@ -1,0 +1,8 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <rect x="4" y="5" width="24" height="22" rx="4" fill="#1F4E79"/>
+  <rect x="8" y="9" width="6" height="6" rx="1.5" fill="#F4B400"/>
+  <rect x="18" y="9" width="6" height="6" rx="1.5" fill="#E8F0FE"/>
+  <rect x="8" y="17" width="6" height="6" rx="1.5" fill="#E8F0FE"/>
+  <path d="M19 20H24" stroke="#F4B400" stroke-width="2" stroke-linecap="round"/>
+  <path d="M21.5 17.5V22.5" stroke="#F4B400" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "Other"
   ],
   "activationEvents": [
+    "onView:architectureStudio.dashboardView",
     "onCommand:architectureStudio.openDashboard",
     "onCommand:architectureStudio.composeStandards",
     "onCommand:architectureStudio.analyzeRepository",
@@ -33,6 +34,24 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "architectureStudio",
+          "title": "Architecture Studio",
+          "icon": "media/architecture-studio.svg"
+        }
+      ]
+    },
+    "views": {
+      "architectureStudio": [
+        {
+          "id": "architectureStudio.dashboardView",
+          "name": "Dashboard",
+          "type": "webview"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "architectureStudio.openDashboard",

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -34,6 +34,7 @@ export const architectureStudioOutputChannelName = "Architecture Studio";
 export interface RegisterArchitectureStudioCommandsOptions {
   readonly services?: StudioCommandServices;
   readonly createServices?: (outputChannel: StudioOutputChannel) => StudioCommandServices;
+  readonly outputChannel?: StudioOutputChannel;
 }
 
 export function registerArchitectureStudioCommands(
@@ -41,7 +42,7 @@ export function registerArchitectureStudioCommands(
   vscodeApi: StudioVscodeApi,
   options: RegisterArchitectureStudioCommandsOptions = {}
 ): void {
-  const outputChannel = vscodeApi.window.createOutputChannel(architectureStudioOutputChannelName);
+  const outputChannel = options.outputChannel ?? vscodeApi.window.createOutputChannel(architectureStudioOutputChannelName);
   const services = options.services ?? options.createServices?.(outputChannel) ?? {};
   context.subscriptions.push(outputChannel);
 

--- a/src/dashboard/createStudioCommandServices.ts
+++ b/src/dashboard/createStudioCommandServices.ts
@@ -1,6 +1,4 @@
 import type { StudioCommandOutput, StudioCommandServices } from "../commands/commandRuntime";
-import { ArchitectureStudioDashboardController, type DashboardCommandsApi, type DashboardWindowApi } from "./dashboardController";
-import type { DashboardResourceUri, DashboardUriApi } from "./dashboardHtml";
 import {
   createArchitectureStudioCoreCli,
   type ArchitectureStudioCoreCli
@@ -8,28 +6,20 @@ import {
 import { createLiveDashboardState } from "./dashboardData";
 
 export type DashboardServiceFactoryContext = {
-  readonly commands: DashboardCommandsApi;
   readonly coreCli?: ArchitectureStudioCoreCli;
   readonly extensionPath?: string;
-  readonly extensionUri: DashboardResourceUri;
   readonly output: StudioCommandOutput;
-  readonly uri: DashboardUriApi;
-  readonly viewColumn: unknown;
-  readonly window: DashboardWindowApi;
+  readonly showDashboard?: () => Promise<void> | void;
   readonly workspace: {
     getFirstWorkspaceFolderPath(): string | undefined;
   };
 };
 
 export function createStudioCommandServices({
-  commands,
   coreCli: providedCoreCli,
   extensionPath,
-  extensionUri,
   output,
-  uri,
-  viewColumn,
-  window,
+  showDashboard,
   workspace
 }: DashboardServiceFactoryContext): StudioCommandServices {
   const coreCli =
@@ -41,22 +31,9 @@ export function createStudioCommandServices({
         })
       : undefined);
   let services: StudioCommandServices;
-  const dashboard = new ArchitectureStudioDashboardController({
-    commands,
-    extensionUri,
-    getState() {
-      return createLiveDashboardState(services);
-    },
-    output,
-    uri,
-    viewColumn,
-    window
-  });
 
   services = {
-    async showDashboard() {
-      await dashboard.show();
-    },
+    ...(showDashboard ? { showDashboard } : {}),
     async getDashboardState() {
       return createLiveDashboardState(services);
     },

--- a/src/dashboard/dashboardSidebarProvider.ts
+++ b/src/dashboard/dashboardSidebarProvider.ts
@@ -1,0 +1,161 @@
+import type { StudioCommandOutput } from "../commands/commandRuntime";
+import { createDashboardState, createDashboardStateMessage, isDashboardWebviewMessage, type DashboardState } from "./dashboardState";
+import { renderDashboardHtml, type DashboardHtmlWebview, type DashboardResourceUri, type DashboardUriApi } from "./dashboardHtml";
+
+export interface DashboardSidebarDisposable {
+  dispose(): void;
+}
+
+export interface DashboardSidebarWebview extends DashboardHtmlWebview {
+  html: string;
+  options?: {
+    readonly enableScripts: boolean;
+    readonly localResourceRoots: readonly unknown[];
+    readonly retainContextWhenHidden?: boolean;
+  };
+  postMessage(message: unknown): PromiseLike<boolean> | boolean;
+  onDidReceiveMessage(listener: (message: unknown) => void): DashboardSidebarDisposable;
+}
+
+export interface DashboardSidebarView {
+  readonly viewType: string;
+  readonly visible: boolean;
+  readonly webview: DashboardSidebarWebview;
+  show(preserveFocus?: boolean): void;
+  onDidDispose(listener: () => void): DashboardSidebarDisposable;
+  onDidChangeVisibility(listener: () => void): DashboardSidebarDisposable;
+}
+
+export interface DashboardSidebarCommandsApi {
+  executeCommand?(commandId: string): PromiseLike<unknown> | unknown;
+}
+
+export interface DashboardSidebarViewProvider {
+  resolveWebviewView(view: DashboardSidebarView, context?: unknown, token?: unknown): Promise<void> | void;
+}
+
+type ArchitectureStudioDashboardSidebarProviderOptions = {
+  readonly commands: DashboardSidebarCommandsApi;
+  readonly extensionUri: DashboardResourceUri;
+  readonly focusCommandId: string;
+  readonly getState?: () => Promise<DashboardState> | DashboardState;
+  readonly nonceFactory?: () => string;
+  readonly output: StudioCommandOutput;
+  readonly uri: DashboardUriApi;
+};
+
+export class ArchitectureStudioDashboardSidebarProvider implements DashboardSidebarViewProvider {
+  private activeView?: DashboardSidebarView;
+  private activeViewDisposables: DashboardSidebarDisposable[] = [];
+  private stateVersion = 0;
+
+  public constructor(private readonly options: ArchitectureStudioDashboardSidebarProviderOptions) {}
+
+  public async show(): Promise<void> {
+    if (this.activeView) {
+      this.activeView.show(false);
+      await this.postState(this.activeView);
+      return;
+    }
+
+    await this.options.commands.executeCommand?.(this.options.focusCommandId);
+  }
+
+  public async resolveWebviewView(view: DashboardSidebarView): Promise<void> {
+    if (this.activeView && this.activeView !== view) {
+      this.releaseView(this.activeView);
+    }
+
+    this.activeView = view;
+
+    const mediaRoot = this.options.uri.joinPath(this.options.extensionUri, "media");
+    view.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [this.options.extensionUri, mediaRoot],
+      retainContextWhenHidden: true
+    };
+
+    const state = await this.getState();
+    view.webview.html = renderDashboardHtml({
+      extensionUri: this.options.extensionUri,
+      nonce: this.createNonce(),
+      state,
+      uri: this.options.uri,
+      webview: view.webview
+    });
+
+    const disposeRegistration = view.onDidDispose(() => {
+      this.options.output.appendLine("[Architecture Studio] Dashboard sidebar disposed.");
+      this.releaseView(view);
+    });
+    const visibilityRegistration = view.onDidChangeVisibility(() => {
+      if (this.activeView === view && view.visible) {
+        void this.postState(view);
+      }
+    });
+    const messageRegistration = view.webview.onDidReceiveMessage((message) => {
+      void this.handleMessage(view, message);
+    });
+
+    this.activeViewDisposables = [disposeRegistration, visibilityRegistration, messageRegistration];
+  }
+
+  private createNonce(): string {
+    return this.options.nonceFactory?.() ?? Math.random().toString(36).slice(2);
+  }
+
+  private async getState(): Promise<DashboardState> {
+    return (await this.options.getState?.()) ?? createDashboardState();
+  }
+
+  private async handleMessage(view: DashboardSidebarView, message: unknown): Promise<void> {
+    if (this.activeView !== view) {
+      return;
+    }
+
+    if (!isDashboardWebviewMessage(message)) {
+      this.options.output.appendLine("[Architecture Studio] Dashboard sidebar ignored unsupported webview message.");
+      return;
+    }
+
+    switch (message.type) {
+      case "dashboard.ready":
+        this.options.output.appendLine("[Architecture Studio] Dashboard sidebar ready message received.");
+        await this.postState(view);
+        break;
+      case "dashboard.runCommand":
+        this.options.output.appendLine(
+          `[Architecture Studio] Dashboard sidebar message received: dashboard.runCommand -> ${message.commandId}`
+        );
+        await this.options.commands.executeCommand?.(message.commandId);
+        await this.postState(view);
+        break;
+    }
+  }
+
+  private async postState(view: DashboardSidebarView): Promise<void> {
+    const requestedVersion = ++this.stateVersion;
+    const state = await this.getState();
+
+    if (this.activeView !== view || requestedVersion !== this.stateVersion) {
+      return;
+    }
+
+    await view.webview.postMessage(createDashboardStateMessage(state));
+  }
+
+  private releaseView(view: DashboardSidebarView): void {
+    if (this.activeView !== view) {
+      return;
+    }
+
+    this.activeView = undefined;
+
+    const disposables = this.activeViewDisposables;
+    this.activeViewDisposables = [];
+
+    for (const disposable of disposables) {
+      disposable.dispose();
+    }
+  }
+}

--- a/src/dashboard/registerDashboardSidebar.ts
+++ b/src/dashboard/registerDashboardSidebar.ts
@@ -1,0 +1,23 @@
+import type { ExtensionContext } from "vscode";
+
+import type { DashboardSidebarViewProvider } from "./dashboardSidebarProvider";
+
+type DisposableLike = { dispose(): void };
+
+export interface DashboardSidebarWindowApi {
+  registerWebviewViewProvider(
+    viewId: string,
+    provider: DashboardSidebarViewProvider
+  ): DisposableLike;
+}
+
+export const architectureStudioDashboardViewId = "architectureStudio.dashboardView";
+export const architectureStudioDashboardViewFocusCommandId = `${architectureStudioDashboardViewId}.focus`;
+
+export function registerArchitectureStudioDashboardSidebar(
+  context: ExtensionContext,
+  windowApi: DashboardSidebarWindowApi,
+  provider: DashboardSidebarViewProvider
+): void {
+  context.subscriptions.push(windowApi.registerWebviewViewProvider(architectureStudioDashboardViewId, provider));
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,59 @@
 import * as vscode from "vscode";
 
+import type { StudioCommandServices } from "./commands/commandRuntime";
+import {
+  architectureStudioOutputChannelName,
+  registerArchitectureStudioCommands
+} from "./commands/registerCommands";
 import { createStudioCommandServices } from "./dashboard/createStudioCommandServices";
-import { registerArchitectureStudioCommands } from "./commands/registerCommands";
+import { ArchitectureStudioDashboardSidebarProvider } from "./dashboard/dashboardSidebarProvider";
+import { createDashboardState } from "./dashboard/dashboardState";
+import {
+  architectureStudioDashboardViewFocusCommandId,
+  registerArchitectureStudioDashboardSidebar
+} from "./dashboard/registerDashboardSidebar";
 
 export function activate(context: vscode.ExtensionContext): void {
+  const outputChannel = vscode.window.createOutputChannel(architectureStudioOutputChannelName);
+  let services: StudioCommandServices;
+  const dashboardSidebarProvider = new ArchitectureStudioDashboardSidebarProvider({
+    commands: {
+      executeCommand(commandId) {
+        return vscode.commands.executeCommand(commandId);
+      }
+    },
+    extensionUri: context.extensionUri,
+    focusCommandId: architectureStudioDashboardViewFocusCommandId,
+    getState() {
+      return services.getDashboardState?.() ?? createDashboardState();
+    },
+    output: outputChannel,
+    uri: vscode.Uri
+  });
+
+  services = createStudioCommandServices({
+    extensionPath: context.extensionPath,
+    output: outputChannel,
+    showDashboard() {
+      return dashboardSidebarProvider.show();
+    },
+    workspace: {
+      getFirstWorkspaceFolderPath() {
+        return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      }
+    }
+  });
+
+  registerArchitectureStudioDashboardSidebar(
+    context,
+    {
+      registerWebviewViewProvider(viewId, provider) {
+        return vscode.window.registerWebviewViewProvider(viewId, provider as vscode.WebviewViewProvider);
+      }
+    },
+    dashboardSidebarProvider
+  );
+
   registerArchitectureStudioCommands(
     context,
     {
@@ -11,34 +61,8 @@ export function activate(context: vscode.ExtensionContext): void {
       window: vscode.window
     },
     {
-        createServices: (outputChannel) =>
-        createStudioCommandServices({
-          commands: {
-            executeCommand(commandId) {
-              return vscode.commands.executeCommand(commandId);
-            }
-          },
-          extensionPath: context.extensionPath,
-          extensionUri: context.extensionUri,
-          output: outputChannel,
-          uri: vscode.Uri,
-          viewColumn: vscode.ViewColumn.One,
-          window: {
-            createWebviewPanel(viewType, title, viewColumn, options) {
-              return vscode.window.createWebviewPanel(
-                viewType,
-                title,
-                viewColumn as vscode.ViewColumn,
-                options as vscode.WebviewPanelOptions & vscode.WebviewOptions
-              );
-            }
-          },
-          workspace: {
-            getFirstWorkspaceFolderPath() {
-              return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-            }
-          }
-        })
+      outputChannel,
+      services
     }
   );
 }

--- a/test/dashboard/createStudioCommandServices.test.ts
+++ b/test/dashboard/createStudioCommandServices.test.ts
@@ -6,7 +6,6 @@ import { createStudioCommandServices } from "../../src/dashboard/createStudioCom
 test("createStudioCommandServices delegates workspace-aware operations to the core CLI bridge", async () => {
   const invokedCommands: string[] = [];
   const services = createStudioCommandServices({
-    commands: {},
     coreCli: {
       async analyzeRepository(workspacePath) {
         invokedCommands.push(`analyze:${workspacePath}`);
@@ -75,28 +74,8 @@ test("createStudioCommandServices delegates workspace-aware operations to the co
       }
     },
     extensionPath: "C:/code/Playground/ARCHITECTURE_STUDIO",
-    extensionUri: {
-      toString() {
-        return "file:///architecture-studio";
-      }
-    },
     output: {
       appendLine() {}
-    },
-    uri: {
-      joinPath(base, ...paths) {
-        return {
-          toString() {
-            return [base.toString(), ...paths].join("/");
-          }
-        };
-      }
-    },
-    viewColumn: 1,
-    window: {
-      createWebviewPanel() {
-        throw new Error("dashboard should not be created in this test");
-      }
     },
     workspace: {
       getFirstWorkspaceFolderPath() {

--- a/test/dashboard/dashboardSidebarManifest.test.ts
+++ b/test/dashboard/dashboardSidebarManifest.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+test("package manifest contributes the Architecture Studio activity bar container and sidebar view", () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8")) as {
+    activationEvents: string[];
+    contributes: {
+      viewsContainers?: {
+        activitybar?: Array<{ id: string; title: string; icon: string }>;
+      };
+      views?: Record<string, Array<{ id: string; name: string; type?: string }>>;
+    };
+  };
+
+  const activityBarContainers = manifest.contributes.viewsContainers?.activitybar ?? [];
+  const architectureStudioContainer = activityBarContainers.find((container) => container.id === "architectureStudio");
+  assert.ok(architectureStudioContainer);
+  assert.equal(architectureStudioContainer.title, "Architecture Studio");
+  assert.equal(architectureStudioContainer.icon, "media/architecture-studio.svg");
+
+  const contributedViews = manifest.contributes.views?.architectureStudio ?? [];
+  assert.deepEqual(contributedViews, [
+    {
+      id: "architectureStudio.dashboardView",
+      name: "Dashboard",
+      type: "webview"
+    }
+  ]);
+
+  assert.ok(manifest.activationEvents.includes("onView:architectureStudio.dashboardView"));
+  assert.ok(fs.existsSync(path.join(process.cwd(), "media", "architecture-studio.svg")));
+});

--- a/test/dashboard/dashboardSidebarProvider.test.ts
+++ b/test/dashboard/dashboardSidebarProvider.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ArchitectureStudioDashboardSidebarProvider } from "../../src/dashboard/dashboardSidebarProvider";
+import { createDashboardState, createEmptySharedContractPayload, createSampleSharedContractPayload } from "../../src/dashboard/dashboardState";
+
+type Disposable = { dispose(): void };
+
+class FakeWebview {
+  public html = "";
+  public options: unknown;
+  public readonly cspSource = "csp-source";
+  public readonly postedMessages: unknown[] = [];
+  public messageListenerDisposals = 0;
+  private readonly listeners = new Set<(message: unknown) => void>();
+
+  asWebviewUri(resource: { toString(): string }) {
+    return {
+      toString() {
+        return `webview:${resource.toString()}`;
+      }
+    };
+  }
+
+  postMessage(message: unknown) {
+    this.postedMessages.push(message);
+    return true;
+  }
+
+  onDidReceiveMessage(listener: (message: unknown) => void): Disposable {
+    this.listeners.add(listener);
+
+    return {
+      dispose: () => {
+        if (this.listeners.delete(listener)) {
+          this.messageListenerDisposals += 1;
+        }
+      }
+    };
+  }
+
+  emit(message: unknown) {
+    for (const listener of this.listeners) {
+      listener(message);
+    }
+  }
+}
+
+class FakeWebviewView {
+  public readonly webview = new FakeWebview();
+  public readonly viewType = "architectureStudio.dashboardView";
+  public showCount = 0;
+  public disposeListenerDisposals = 0;
+  public visible = true;
+  private readonly disposeListeners = new Set<() => void>();
+  private readonly visibilityListeners = new Set<() => void>();
+
+  onDidDispose(listener: () => void): Disposable {
+    this.disposeListeners.add(listener);
+
+    return {
+      dispose: () => {
+        if (this.disposeListeners.delete(listener)) {
+          this.disposeListenerDisposals += 1;
+        }
+      }
+    };
+  }
+
+  onDidChangeVisibility(listener: () => void): Disposable {
+    this.visibilityListeners.add(listener);
+
+    return {
+      dispose: () => {
+        this.visibilityListeners.delete(listener);
+      }
+    };
+  }
+
+  show() {
+    this.showCount += 1;
+  }
+
+  dispose() {
+    for (const listener of [...this.disposeListeners]) {
+      listener();
+    }
+  }
+}
+
+test("dashboard sidebar provider contributes the webview view and focuses it when requested", async () => {
+  const executedCommands: string[] = [];
+  const view = new FakeWebviewView();
+  const provider = new ArchitectureStudioDashboardSidebarProvider({
+    commands: {
+      executeCommand(commandId: string) {
+        executedCommands.push(commandId);
+      }
+    },
+    extensionUri: {
+      toString() {
+        return "extension:/root";
+      }
+    },
+    focusCommandId: "architectureStudio.dashboardView.focus",
+    getState() {
+      return createDashboardState(createSampleSharedContractPayload(), {
+        workspaceLabel: "fintech-platform"
+      });
+    },
+    output: {
+      appendLine() {}
+    },
+    uri: {
+      joinPath(base: { toString(): string }, ...paths: string[]) {
+        return {
+          toString() {
+            return [base.toString(), ...paths].join("/");
+          }
+        };
+      }
+    }
+  });
+
+  await provider.show();
+  assert.deepEqual(executedCommands, ["architectureStudio.dashboardView.focus"]);
+
+  await provider.resolveWebviewView(view as never);
+  assert.match(view.webview.html, /Architecture/);
+  assert.match(view.webview.html, /dashboard\.css/);
+  assert.match(view.webview.html, /dashboard\.js/);
+
+  await provider.show();
+  assert.equal(view.showCount, 1);
+});
+
+test("dashboard sidebar provider uses the typed message bridge and refreshes after command execution", async () => {
+  let currentState = createDashboardState(
+    createSampleSharedContractPayload({
+      complianceSummaries: [
+        {
+          regulationId: "hipaa",
+          regulationTitle: "HIPAA",
+          scorePercentage: 68,
+          coveredControls: 2,
+          totalControls: 3
+        }
+      ]
+    }),
+    {
+      workspaceLabel: "fintech-platform"
+    }
+  );
+  const executedCommands: string[] = [];
+  const outputLines: string[] = [];
+  const view = new FakeWebviewView();
+  const provider = new ArchitectureStudioDashboardSidebarProvider({
+    commands: {
+      async executeCommand(commandId: string) {
+        executedCommands.push(commandId);
+        currentState = createDashboardState(createEmptySharedContractPayload(), {
+          workspaceLabel: "fintech-platform",
+          subtitle: "Live workspace summary for fintech-platform."
+        });
+      }
+    },
+    extensionUri: {
+      toString() {
+        return "extension:/root";
+      }
+    },
+    focusCommandId: "architectureStudio.dashboardView.focus",
+    getState: async () => currentState,
+    output: {
+      appendLine(line: string) {
+        outputLines.push(line);
+      }
+    },
+    uri: {
+      joinPath(base: { toString(): string }, ...paths: string[]) {
+        return {
+          toString() {
+            return [base.toString(), ...paths].join("/");
+          }
+        };
+      }
+    }
+  });
+
+  await provider.resolveWebviewView(view as never);
+
+  view.webview.emit({ type: "dashboard.ready" });
+  view.webview.emit({
+    type: "dashboard.runCommand",
+    commandId: "architectureStudio.generateReports"
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(executedCommands[0], "architectureStudio.generateReports");
+  assert.ok(view.webview.postedMessages.length >= 1);
+  assert.equal(
+    (view.webview.postedMessages.at(-1) as { state: { subtitle: string } }).state.subtitle,
+    "Live workspace summary for fintech-platform."
+  );
+
+  view.dispose();
+  assert.equal(view.webview.messageListenerDisposals, 1);
+  assert.equal(view.disposeListenerDisposals, 1);
+  assert.ok(outputLines.some((line) => line.includes("dashboard.runCommand")));
+});

--- a/test/dashboard/registerDashboardSidebar.test.ts
+++ b/test/dashboard/registerDashboardSidebar.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  architectureStudioDashboardViewId,
+  registerArchitectureStudioDashboardSidebar
+} from "../../src/dashboard/registerDashboardSidebar";
+
+type Disposable = { dispose(): void };
+
+test("registerArchitectureStudioDashboardSidebar wires the dashboard sidebar provider into the contributed view id", () => {
+  const subscriptions: Disposable[] = [];
+  let registeredViewId = "";
+  const provider = {
+    resolveWebviewView() {}
+  };
+
+  registerArchitectureStudioDashboardSidebar(
+    {
+      subscriptions
+    } as never,
+    {
+      registerWebviewViewProvider(viewId, registeredProvider) {
+        registeredViewId = viewId;
+        assert.equal(registeredProvider, provider);
+        return { dispose() {} };
+      }
+    },
+    provider
+  );
+
+  assert.equal(registeredViewId, architectureStudioDashboardViewId);
+  assert.equal(subscriptions.length, 1);
+});


### PR DESCRIPTION
﻿## Summary
- contribute an `Architecture Studio` Activity Bar container and sidebar-hosted webview dashboard
- register a shared sidebar provider that reuses the existing dashboard HTML, state projection, and typed message bridge
- make `Architecture Studio: Open Dashboard` focus the sidebar view, and update docs/tests for the new UX

## Validation
- npm test -- --test test/dashboard/dashboardSidebarManifest.test.ts test/dashboard/registerDashboardSidebar.test.ts test/dashboard/dashboardSidebarProvider.test.ts test/dashboard/createStudioCommandServices.test.ts
- npm run verify
- dotnet test core/ArchitectureStudio.sln
- npm run package:extension
- code --install-extension .\architecture-studio-0.1.0.vsix --force
- installed extension manifest check at `%USERPROFILE%\.vscode\extensions\tmassey1979.architecture-studio-0.1.0\package.json`

Depends on #28
Closes #29
