### PR TITLE
Support restricted-mode dashboard activation

### DIFF
--- a/changelog/2026-03-12-issue-31-workspace-trust-support.md
+++ b/changelog/2026-03-12-issue-31-workspace-trust-support.md
@@ -1,0 +1,15 @@
+# 2026-03-12 Issue 31 Workspace Trust Support
+
+## Summary
+
+- declared Restricted Mode support in the VS Code extension manifest
+- added manifest regression coverage for untrusted workspace capability
+- documented how Workspace Trust affects the dashboard sidebar
+
+## Validation
+
+- `npm test -- --test test/dashboard/dashboardSidebarManifest.test.ts`
+- `npm run verify`
+- `dotnet test core/ArchitectureStudio.sln`
+- `npm run package:extension`
+- `code --install-extension .\\architecture-studio-0.1.0.vsix --force`

--- a/docs/developer/dashboard-webview.md
+++ b/docs/developer/dashboard-webview.md
@@ -48,6 +48,10 @@ The bridge is intentionally small. The webview consumes DTOs only and does not k
 - dashboard-triggered commands refresh the state after execution so the view does not keep stale data
 - async state refreshes are versioned so older responses do not overwrite newer ones
 
+## Workspace Trust
+
+The extension manifest now declares `capabilities.untrustedWorkspaces.supported: true` so the contributed Activity Bar view can activate in VS Code Restricted Mode. This is safe for the current product boundary because the extension executes only packaged binaries and reads workspace files locally; it does not execute workspace-provided code as part of dashboard activation.
+
 ## Live Snapshot Model
 
 The live dashboard snapshot is assembled in TypeScript as a thin orchestration layer over the C# engines:

--- a/docs/user/dashboard.md
+++ b/docs/user/dashboard.md
@@ -48,3 +48,15 @@ The current dashboard story now delivers:
 - refresh after dashboard-triggered commands
 
 Use the `Architecture Studio` item in the left sidebar, then run `Architecture Studio: Open Dashboard` any time you want VS Code to focus that view for you. Use the sample fintech fixture or your own workspace to see the live cards and evidence panels populate.
+
+## Restricted Mode And Workspace Trust
+
+Architecture Studio now declares support for VS Code Restricted Mode. If your folder opens as untrusted, the `Architecture Studio` Activity Bar item and dashboard should still load because the extension only uses its own packaged engine binaries and reads local workspace files for analysis.
+
+If VS Code is still showing the workspace as restricted or hiding the view, use these checks:
+
+1. Run `Developer: Reload Window`.
+2. Run `Workspaces: Manage Workspace Trust`.
+3. Confirm the installed `Architecture Studio` extension version is the latest packaged build.
+
+Trust the workspace only if you want VS Code to remove the global Restricted Mode banner for that folder. The Architecture Studio sidebar itself should no longer require that trust decision just to open.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
   "engines": {
     "vscode": "^1.95.0"
   },
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": true,
+      "description": "Architecture Studio supports Restricted Mode for local dashboard and analysis workflows without requiring workspace trust."
+    }
+  },
   "categories": [
     "Other"
   ],

--- a/test/dashboard/dashboardSidebarManifest.test.ts
+++ b/test/dashboard/dashboardSidebarManifest.test.ts
@@ -6,6 +6,12 @@ import test from "node:test";
 test("package manifest contributes the Architecture Studio activity bar container and sidebar view", () => {
   const manifest = JSON.parse(fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8")) as {
     activationEvents: string[];
+    capabilities?: {
+      untrustedWorkspaces?: {
+        supported?: boolean | "limited";
+        description?: string;
+      };
+    };
     contributes: {
       viewsContainers?: {
         activitybar?: Array<{ id: string; title: string; icon: string }>;
@@ -30,5 +36,10 @@ test("package manifest contributes the Architecture Studio activity bar containe
   ]);
 
   assert.ok(manifest.activationEvents.includes("onView:architectureStudio.dashboardView"));
+  assert.equal(manifest.capabilities?.untrustedWorkspaces?.supported, true);
+  assert.match(
+    manifest.capabilities?.untrustedWorkspaces?.description ?? "",
+    /restricted mode|workspace trust|untrusted workspace/i
+  );
   assert.ok(fs.existsSync(path.join(process.cwd(), "media", "architecture-studio.svg")));
 });


### PR DESCRIPTION
﻿## Summary
- declare Restricted Mode support in the extension manifest
- cover the Workspace Trust capability with a manifest regression test
- document how to use the dashboard when VS Code opens a folder in Restricted Mode

## Validation
- npm test -- --test test/dashboard/dashboardSidebarManifest.test.ts
- npm run verify
- dotnet test core/ArchitectureStudio.sln
- npm run package:extension
- code --install-extension .\architecture-studio-0.1.0.vsix --force

Closes #31
